### PR TITLE
Fix: Add authorization checks to get_recent_nonce and remove fallback nonce bypass

### DIFF
--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -2330,16 +2330,12 @@ class UR_AJAX {
 			}
 		}
 
-		// Strict referer verification
-		$referer      = wp_get_referer();
-		$allowed_host = parse_url( home_url(), PHP_URL_HOST );
-		$referer_host = parse_url( $referer, PHP_URL_HOST );
-
-		if ( ! $referer || $referer_host !== $allowed_host ) {
+		if ( ! is_user_logged_in() || ! current_user_can( 'edit_posts' ) ) {
 			wp_send_json_error(
 				array(
-					__( 'Invalid form submission source.', 'user-registration' ),
-				)
+					'message' => __( 'Permission denied.', 'user-registration' ),
+				),
+				403
 			);
 		}
 		$updated_nonce_array = array();

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -5513,7 +5513,7 @@ if ( ! function_exists( 'ur_process_registration' ) ) {
 			);
 		}
 
-		if ( ! check_ajax_referer( 'user_registration_form_data_save_nonce', 'security', false ) && empty( $_POST['ur_fallback_submit'] ) ) {
+		if ( ! check_ajax_referer( 'user_registration_form_data_save_nonce', 'security', false ) ) {
 			$logger->error(
 				sprintf( '[Form #%d] AJAX nonce verification failed for form submission.', $form_id ) . "\n   ",
 				array(


### PR DESCRIPTION
## Summary

This PR fixes an authorization bypass vulnerability (CWE-306) that allows unauthenticated attackers to create unauthorized WordPress user accounts.

## Vulnerability Details

1. **Forgeable Referer-only check** in  (, lines 2334-2344):
   - The only protection was  which is trivially forgeable via HTTP headers
   - The nonce generated here () matches the action name checked in , enabling attackers to obtain valid submission nonces without authentication

2. **Fallback nonce bypass** in  (, line 5516):
   - The  POST parameter allowed attackers to completely skip the primary nonce verification

## Fix

1. Replace the Referer-only check in  with  + 
2. Remove the  bypass in  so nonce verification is always enforced

## Impact

- Unauthenticated attackers can create WordPress Subscriber accounts on any site with a published registration form
- Bypasses the WordPress "Anyone can register" setting
- 70,000+ active installations affected

## CVSS 3.1

 (8.1 High)