### PR TITLE
UR-4738 Fix - Change Plan redirects to default language membership page

### DIFF
--- a/templates/myaccount/membership.php
+++ b/templates/myaccount/membership.php
@@ -208,9 +208,9 @@ $current_url = get_permalink( get_option( 'user_registration_myaccount_page_id' 
 										} else {
 
 											if ( isset( $data['is_upgrading'] ) && ! $data['is_upgrading'] && ! empty( $membership ) ) :
-												$membership_checkout_page_id = get_option( 'user_registration_member_registration_page_id', false );
+												$membership_checkout_page_id = ur_get_translated_page_id( get_option( 'user_registration_member_registration_page_id', false ) );
 												$redirect_page_url           = get_permalink( $membership_checkout_page_id );
-												$thank_you_page_id           = get_option( 'user_registration_thank_you_page_id', false );
+												$thank_you_page_id           = ur_get_translated_page_id( get_option( 'user_registration_thank_you_page_id', false ) );
 												$uuid                        = ur_generate_random_key();
 												$subscription_id             = $membership['subscription_id'];
 												$redirect_link_builder       = array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

On a multilingual site, the **Change Plan** button in the My Account → Membership tab always sent the user to the default-language membership registration page, dropping them out of the language they were browsing in.

**Root cause**

`templates/myaccount/membership.php` read `user_registration_member_registration_page_id` and `user_registration_thank_you_page_id` straight from the options table:

```php
$membership_checkout_page_id = get_option( 'user_registration_member_registration_page_id', false );
$redirect_page_url           = get_permalink( $membership_checkout_page_id );
$thank_you_page_id           = get_option( 'user_registration_thank_you_page_id', false );
```

Those options always hold the **default-language** page ID, so `get_permalink()` returned the default-language URL no matter which language was active. The same `$redirect_page_url` also backs the **Renew Membership** link, so it had the identical problem.

**Fix**

Wrap both option reads in the existing `ur_get_translated_page_id()` helper (`includes/functions-ur-page.php`), which maps a stored page ID to its Polylang/WPML translation for the current language and falls back to the original ID when no translation exists or no multilingual plugin is active. Template-only change; single-language sites are unaffected because the helper is a no-op without Polylang/WPML.

Closes UR-4738.

### How to test the changes in this Pull Request:

1. Activate Polylang with two languages (English default + French) and translate the membership registration page and the thank-you page.
2. Enable the Upgradeable Membership feature and set an upgrade path so a plan has upgradable plans.
3. Log in as a user with an active membership on that plan, and open the **translated** My Account page → **Membership** tab.
4. Inspect the **Change Plan** link.
   - **Before this fix:** points at the default-language page — `?page_id=20&action=upgrade&…&thank_you=22`.
   - **After this fix:** points at the translated page — `?page_id=709&lang=fr&action=upgrade&…&thank_you=708`.
5. Repeat on the default-language account page — the link is unchanged.
6. Regression: same check on the **Renew Membership** link, which is built from the same `$redirect_page_url`.
7. Regression: deactivate Polylang/WPML entirely and confirm both links still resolve to the configured registration page.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Change Plan and Renew Membership links redirecting to the default language membership page on multilingual sites.
