### PR TITLE
UR-4739 Fix - Membership group listing redirects to default language page

### DIFF
--- a/includes/blocks/block-types/class-ur-block-membership-buy-now.php
+++ b/includes/blocks/block-types/class-ur-block-membership-buy-now.php
@@ -55,7 +55,7 @@ class UR_Block_Membership_Buy_Now extends UR_Block_Abstract {
 		$block_id = isset( $this->attributes['clientId'] ) ? $this->attributes['clientId'] : '';
 		$attr     = $this->attributes;
 
-		$page_id = get_option( 'user_registration_member_registration_page_id' );
+		$page_id = ur_get_translated_page_id( get_option( 'user_registration_member_registration_page_id' ) );
 
 		$page_url = get_permalink( absint( $page_id ) );
 
@@ -302,7 +302,7 @@ class UR_Block_Membership_Buy_Now extends UR_Block_Abstract {
 		$membership_details = $membership_repository->get_single_membership_by_ID( $membership_id );
 
 		$intended_action = $membership_service->fetch_intended_action( $action_to_take, $membership_details, $user_membership_ids );
-		$thank_you_page_id   = get_option( 'user_registration_thank_you_page_id', false );
+		$thank_you_page_id   = ur_get_translated_page_id( get_option( 'user_registration_thank_you_page_id', false ) );
 
 		$redirect_link_builder = array(
 				'action'  => $intended_action,

--- a/modules/membership/includes/Admin/Views/Shortcode/MembershipListingShortcode.php
+++ b/modules/membership/includes/Admin/Views/Shortcode/MembershipListingShortcode.php
@@ -117,8 +117,8 @@ class MembershipListingShortcode {
 		$currency             = get_option( 'user_registration_payment_currency', 'USD' );
 		$currencies           = ur_payment_integration_get_currencies();
 		$symbol               = $currencies[ $currency ]['symbol'];
-		$registration_page_id = ! empty( $attributes['registration_page_id'] ) ? absint( $attributes['registration_page_id'] ) : get_option( 'user_registration_member_registration_page_id', false );
-		$thank_you_page_id    = ! empty( $attributes['thank_you_page_id'] ) ? absint( $attributes['thank_you_page_id'] ) : get_option( 'user_registration_thank_you_page_id', false );
+		$registration_page_id = ur_get_translated_page_id( ! empty( $attributes['registration_page_id'] ) ? absint( $attributes['registration_page_id'] ) : get_option( 'user_registration_member_registration_page_id', false ) );
+		$thank_you_page_id    = ur_get_translated_page_id( ! empty( $attributes['thank_you_page_id'] ) ? absint( $attributes['thank_you_page_id'] ) : get_option( 'user_registration_thank_you_page_id', false ) );
 		$uuid                 = ! empty( $attributes['uuid'] ) ? $attributes['uuid'] : ur_generate_random_key();
 		$redirect_page_url    = get_permalink( $registration_page_id );
 
@@ -135,7 +135,7 @@ class MembershipListingShortcode {
 					$user_memberships
 				)
 			);
-			$membership_checkout_page_id = get_option( 'user_registration_member_registration_page_id', false );
+			$membership_checkout_page_id = ur_get_translated_page_id( get_option( 'user_registration_member_registration_page_id', false ) );
 
 			$redirect_page_url = get_permalink( $membership_checkout_page_id );
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

On a multilingual site, the membership group / plans listing sends the visitor to the **default-language** membership registration page, dropping them out of the language they were browsing in. Same root cause as UR-4738 (PR #1369), different surface.

**Root cause**

`MembershipListingShortcode::get_content()` (behind `[user_registration_groups]`) and the **Membership Buy Now** block both read `user_registration_member_registration_page_id` / `user_registration_thank_you_page_id` straight from the options table:

```php
$registration_page_id = ! empty( $attributes['registration_page_id'] ) ? absint( $attributes['registration_page_id'] ) : get_option( 'user_registration_member_registration_page_id', false );
$redirect_page_url    = get_permalink( $registration_page_id );
```

Those options always hold the **default-language** page ID, so `get_permalink()` returns the default-language URL regardless of the active language. The listing template passes that value on to every plan's `data-redirect`, `redirect_page_url` and `thank_you_page_id`, so the whole group renders default-language checkout links. The shortcode's logged-in branch recomputes `$redirect_page_url` from the same option, so it was affected too.

**Fix**

Route both page IDs through the existing `ur_get_translated_page_id()` helper (`includes/functions-ur-page.php`), which maps a stored page ID to its Polylang/WPML translation for the current language and falls back to the original ID when no translation exists or no multilingual plugin is active.

In the shortcode the helper wraps the **fully-resolved** ID rather than just the option, so an explicitly-set `registration_page_id` / `thank_you_page_id` block attribute is translated too — otherwise a translated page carrying a copied block would still hold the default-language ID. Single-language sites are unaffected because the helper is a no-op without Polylang/WPML.

Closes UR-4739.

### How to test the changes in this Pull Request:

1. Activate Polylang with two languages (English default + French) and translate the membership registration page and the thank-you page.
2. Create a Membership Group, put `[user_registration_groups]` on a page, and translate that page too.
3. Visit the **translated** plans page and inspect a plan's checkout link (`data-redirect`, or the `redirect_page_url` hidden input).
   - **Before this fix:** `?page_id=20` with `thank_you_page_id=22` (default language).
   - **After this fix:** `?page_id=709&lang=fr` with `thank_you_page_id=708` (translated).
4. Repeat on a page using the **Membership Buy Now** block.
   - **Before this fix:** `?page_id=20&action=register&…&thank_you=22`.
   - **After this fix:** `?page_id=709&lang=fr&action=register&…&thank_you=708`.
5. Load both pages in the default language — links are unchanged.
6. Regression: check both logged-out and logged-in, since the shortcode resolves the redirect URL on two separate paths.
7. Regression: deactivate Polylang/WPML entirely and confirm the listing and block still link to the configured registration page.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Membership group listing and Buy Now block linking to the default language registration page on multilingual sites.
