### PR TITLE
UR-4791 Fix - Profile Picture silently wiped when Save Changes is used on another user's profile

### DIFF
--- a/includes/frontend/class-ur-frontend.php
+++ b/includes/frontend/class-ur-frontend.php
@@ -93,10 +93,11 @@ class UR_Frontend {
 				$form_data = json_decode( wp_unslash( $_POST['form_data'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 			foreach ( $form_data as $data ) {
-				if ( isset( $data->field_name ) && 'user_registration_profile_pic_url' === $data->field_name ) {
+				// Unrendered fields send field_name only - require value too, or this wipes the picture.
+				if ( isset( $data->field_name, $data->value ) && 'user_registration_profile_pic_url' === $data->field_name ) {
 					if ( ! is_array( $data->value ) && ! ur_is_valid_url( $data->value ) ) {
 						$valid_form_data['profile_pic_url']        = new stdClass();
-						$valid_form_data['profile_pic_url']->value = isset( $data->value ) ? $data->value : '';
+						$valid_form_data['profile_pic_url']->value = $data->value;
 					}
 				}
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

wp-admin's User Details "Save Changes" screen doesn't render the Profile Picture field (it's shown only as a read-only sidebar avatar), but its JS still submits a field-name-only stub for it in `form_data` regardless. `UR_Frontend::user_registration_before_save_profile_details()` treated a missing `value` property the same as an explicit empty one, which flowed into `ur_upload_profile_pic()` and ended in `update_user_meta( $user_id, 'user_registration_profile_pic_url', '' )` — silently wiping the member's existing profile picture on every admin save, even with no changes made.

Fix: require the submitted entry to actually carry a `value` property (`isset( $data->field_name, $data->value )`) before treating it as real data for this field. Fields absent from the current submission are now left untouched instead of defaulting to empty.

Jira: UR-4791 (https://themegrill.atlassian.net/browse/UR-4791)

Closes # .

### How to test the changes in this Pull Request:

1. Register a user through a form with a "Profile Picture" field, uploading a picture.
2. As admin, open that user's User Details page in wp-admin (User Registration & Membership → Members → user).
3. Without changing anything, click "Save Changes", then reload the page.
4. Before this fix: the Profile Picture reverts to the default Gravatar. After this fix: it's unchanged.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?

### Changelog entry

> Fix - Profile Picture removed when saving another user's profile.