### PR TITLE
UR-4784 Fix - Hide Renewal Behaviour setting when no membership plans exist

### DIFF
--- a/includes/admin/settings/class-ur-settings-membership.php
+++ b/includes/admin/settings/class-ur-settings-membership.php
@@ -76,43 +76,80 @@ if ( ! class_exists( 'UR_Settings_Membership' ) ) {
 				 *
 				 * @param array Options to be enlisted.
 				 */
-				$settings = apply_filters(
-					'user_registration_membership_settings',
-					array(
-						'title'    => '',
-						'sections' => array(
-							'membership_settings' => array(
-								'title'    => __( 'General', 'user-registration' ),
-								'type'     => 'card',
-								'desc'     => sprintf(
-									/* translators: %s - Admin URL for membership page settings */
-									__( '<strong>Membership page setting has moved.</strong> Configure your membership page <a href="%s">here</a>.', 'user-registration' ),
-									admin_url( 'admin.php?page=user-registration-settings&tab=general&section=pages' )
-								),
-								'settings' => array(
-									array(
-										'title'    => __( 'Renewal Behaviour', 'user-registration' ),
-										'desc'     => __( 'Choose how membership subscriptions are renewed, automatically through the payment provider or manually by the user', 'user-registration' ),
-										'id'       => 'user_registration_renewal_behaviour',
-										'type'     => 'select',
-										'default'  => 'automatic',
-										'class'    => 'ur-enhanced-select',
-										'css'      => '',
-										'options'  => array(
-											'automatic' => __( 'Renew Automatically', 'user-registration' ),
-											'manual'    => __( 'Renew Manually', 'user-registration' ),
-										),
-										'desc_tip' => true,
-									),
-								),
-							),
-						),
-					)
-				);
+				$settings = apply_filters( 'user_registration_membership_settings', $this->get_general_membership_settings() );
 			} elseif ( 'content-rules' === $current_section ) {
 				$settings = $this->urcr_settings();
 			}
 			return $settings;
+		}
+
+		/**
+		 * General membership settings (Renewal Behaviour), or an empty-state
+		 * notice in place of it when no membership plans exist yet.
+		 *
+		 * @return array
+		 */
+		private function get_general_membership_settings() {
+			$card = array(
+				'title' => __( 'General', 'user-registration' ),
+				'type'  => 'card',
+			);
+
+			if ( ! $this->has_membership_plans() ) {
+				$card['desc']     = sprintf(
+					/* translators: %s - Admin URL to create a new membership plan */
+					__( '<strong>No membership plans yet.</strong> Set up a plan to configure the Renewal Behaviour. <a href="%s">Create a membership &rarr;</a>', 'user-registration' ),
+					admin_url( 'admin.php?page=user-registration-membership&action=add_new_membership' )
+				);
+				$card['settings'] = array();
+			} else {
+				$is_new_installation = ur_string_to_bool( get_option( 'urm_is_new_installation', '' ) );
+				if ( ! $is_new_installation ) {
+					$card['desc'] = sprintf(
+						/* translators: %s - Admin URL for membership page settings */
+						__( '<strong>Membership page setting has moved.</strong> Configure your membership page <a href="%s">here</a>.', 'user-registration' ),
+						admin_url( 'admin.php?page=user-registration-settings&tab=general&section=pages' )
+					);
+				}
+				$card['settings'] = array(
+					array(
+						'title'    => __( 'Renewal Behaviour', 'user-registration' ),
+						'desc'     => __( 'Choose how membership subscriptions are renewed, automatically through the payment provider or manually by the user', 'user-registration' ),
+						'id'       => 'user_registration_renewal_behaviour',
+						'type'     => 'select',
+						'default'  => 'automatic',
+						'class'    => 'ur-enhanced-select',
+						'css'      => '',
+						'options'  => array(
+							'automatic' => __( 'Renew Automatically', 'user-registration' ),
+							'manual'    => __( 'Renew Manually', 'user-registration' ),
+						),
+						'desc_tip' => true,
+					),
+				);
+			}
+
+			return array(
+				'title'    => '',
+				'sections' => array(
+					'membership_settings' => $card,
+				),
+			);
+		}
+
+		/**
+		 * Whether at least one published membership plan exists.
+		 *
+		 * @return bool
+		 */
+		private function has_membership_plans() {
+			if ( ! class_exists( 'WPEverest\URMembership\Admin\Repositories\MembershipRepository' ) ) {
+				return true;
+			}
+
+			$membership_repository = new WPEverest\URMembership\Admin\Repositories\MembershipRepository();
+
+			return ! empty( $membership_repository->get_all_membership() );
 		}
 
 		/**

--- a/includes/admin/settings/class-ur-settings-membership.php
+++ b/includes/admin/settings/class-ur-settings-membership.php
@@ -85,7 +85,7 @@ if ( ! class_exists( 'UR_Settings_Membership' ) ) {
 
 		/**
 		 * General membership settings (Renewal Behaviour), or an empty-state
-		 * notice in place of it when no membership plans exist yet.
+		 * notice in place of it when no active membership plan exists yet.
 		 *
 		 * @return array
 		 */
@@ -95,12 +95,23 @@ if ( ! class_exists( 'UR_Settings_Membership' ) ) {
 				'type'  => 'card',
 			);
 
-			if ( ! $this->has_membership_plans() ) {
-				$card['desc']     = sprintf(
-					/* translators: %s - Admin URL to create a new membership plan */
-					__( '<strong>No membership plans yet.</strong> Set up a plan to configure the Renewal Behaviour. <a href="%s">Create a membership &rarr;</a>', 'user-registration' ),
-					admin_url( 'admin.php?page=user-registration-membership&action=add_new_membership' )
-				);
+			$plan_state = $this->get_membership_plan_state();
+
+			if ( 'active' !== $plan_state ) {
+				if ( 'inactive' === $plan_state ) {
+					$card['desc'] = sprintf(
+						/* translators: %s - Admin URL to the membership plan list */
+						__( '<strong>No active membership plan.</strong> Activate a plan to configure the Renewal Behaviour. <a href="%s">Manage memberships &rarr;</a>', 'user-registration' ),
+						admin_url( 'admin.php?page=user-registration-membership' )
+					);
+				} else {
+					$card['desc'] = sprintf(
+						/* translators: %s - Admin URL to create a new membership plan */
+						__( '<strong>No membership plans yet.</strong> Set up a plan to configure the Renewal Behaviour. <a href="%s">Create a membership &rarr;</a>', 'user-registration' ),
+						admin_url( 'admin.php?page=user-registration-membership&action=add_new_membership' )
+					);
+				}
+
 				$card['settings'] = array();
 			} else {
 				$is_new_installation = ur_string_to_bool( get_option( 'urm_is_new_installation', '' ) );
@@ -138,18 +149,38 @@ if ( ! class_exists( 'UR_Settings_Membership' ) ) {
 		}
 
 		/**
-		 * Whether at least one published membership plan exists.
+		 * State of the published membership plans.
 		 *
-		 * @return bool
+		 * Deactivated plans do not count as usable, since there is nothing to
+		 * renew while every plan is switched off.
+		 *
+		 * @return string One of 'active' (at least one active plan exists),
+		 *                'inactive' (plans exist but all are deactivated) or
+		 *                'none' (no plan has been created yet).
 		 */
-		private function has_membership_plans() {
+		private function get_membership_plan_state() {
 			if ( ! class_exists( 'WPEverest\URMembership\Admin\Repositories\MembershipRepository' ) ) {
-				return true;
+				return 'active';
 			}
 
 			$membership_repository = new WPEverest\URMembership\Admin\Repositories\MembershipRepository();
+			$memberships           = $membership_repository->get_all_memberships_without_status_filter();
+			$has_plan              = false;
 
-			return ! empty( $membership_repository->get_all_membership() );
+			foreach ( $memberships as $membership ) {
+				if ( ! isset( $membership['post_status'] ) || 'publish' !== $membership['post_status'] ) {
+					continue;
+				}
+
+				$has_plan = true;
+				$status   = isset( $membership['post_content']['status'] ) ? $membership['post_content']['status'] : false;
+
+				if ( ur_string_to_bool( $status ) ) {
+					return 'active';
+				}
+			}
+
+			return $has_plan ? 'inactive' : 'none';
 		}
 
 		/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

On Settings > Membership > General, the Renewal Behaviour dropdown showed up even when no membership plan had been created yet, which didn't make sense since there was nothing to renew. Now, if no membership plans exist, the dropdown is replaced with a short message telling the user to create a plan first, with a link to do so.

Also fixed the "Membership page setting has moved" message on the same tab so it only shows on existing/upgraded sites, not on brand new installs (it didn't make sense there since nothing had "moved" for them).

Closes #UR-4784.

### How to test the changes in this Pull Request:

1. On a site with no membership plans, open Settings > Membership > General and confirm the Renewal Behaviour field is gone and the "Create a membership" message/link shows instead.
2. Create a membership plan, reload the tab, confirm Renewal Behaviour is back and still saves correctly.
3. On a fresh install, confirm the "Membership page setting has moved" message does not appear; on an existing/upgraded install, confirm it still does.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Fix: Hide Renewal Behaviour setting on Membership settings until a membership plan is created.