### PR TITLE
UR-4783 Fix - Hide Content Restriction settings when no membership plans or custom rules exist

### DIFF
--- a/includes/admin/settings/class-ur-settings-membership.php
+++ b/includes/admin/settings/class-ur-settings-membership.php
@@ -144,26 +144,38 @@ if ( ! class_exists( 'UR_Settings_Membership' ) ) {
 				$has_membership_plans  = ! empty( $membership_repository->get_all_memberships_without_status_filter() );
 			}
 
-			// 'custom' excludes membership-generated and auto-migrated rules, which carry other/no rule_type.
-			$has_custom_content_rules = false;
+			/*
+			 * Rules that prove content restriction is actually in use:
+			 * - 'custom' rules, which can only be created in Pro.
+			 * - the auto-migrated "Legacy: Global Site Rule" (flagged with urcr_is_global), present on
+			 *   older installs that used the old global restriction setting, in both free and Pro.
+			 * Membership-generated rules are deliberately excluded, they are already covered by
+			 * $has_membership_plans.
+			 */
+			$has_content_rules = false;
 			if ( post_type_exists( 'urcr_access_rule' ) ) {
-				$has_custom_content_rules = (bool) get_posts(
+				$has_content_rules = (bool) get_posts(
 					array(
 						'post_type'      => 'urcr_access_rule',
 						'post_status'    => 'any',
 						'posts_per_page' => 1,
 						'fields'         => 'ids',
 						'meta_query'     => array(
+							'relation' => 'OR',
 							array(
 								'key'   => 'urcr_rule_type',
 								'value' => 'custom',
+							),
+							array(
+								'key'     => 'urcr_is_global',
+								'compare' => 'EXISTS',
 							),
 						),
 					)
 				);
 			}
 
-			$has_restriction_in_use = $has_membership_plans || $has_custom_content_rules;
+			$has_restriction_in_use = $has_membership_plans || $has_content_rules;
 
 			$sections['user_registration_content_restriction_settings'] = array(
 				'title'    => __( 'Content Restriction', 'user-registration' ),

--- a/includes/admin/settings/class-ur-settings-membership.php
+++ b/includes/admin/settings/class-ur-settings-membership.php
@@ -137,10 +137,38 @@ if ( ! class_exists( 'UR_Settings_Membership' ) ) {
 			if ( ! empty( $global_rule_id ) ) {
 				$content_rule_url .= '&id=' . $global_rule_id;
 			}
+
+			$has_membership_plans = false;
+			if ( class_exists( 'WPEverest\URMembership\Admin\Repositories\MembershipRepository' ) ) {
+				$membership_repository = new \WPEverest\URMembership\Admin\Repositories\MembershipRepository();
+				$has_membership_plans  = ! empty( $membership_repository->get_all_memberships_without_status_filter() );
+			}
+
+			// 'custom' excludes membership-generated and auto-migrated rules, which carry other/no rule_type.
+			$has_custom_content_rules = false;
+			if ( post_type_exists( 'urcr_access_rule' ) ) {
+				$has_custom_content_rules = (bool) get_posts(
+					array(
+						'post_type'      => 'urcr_access_rule',
+						'post_status'    => 'any',
+						'posts_per_page' => 1,
+						'fields'         => 'ids',
+						'meta_query'     => array(
+							array(
+								'key'   => 'urcr_rule_type',
+								'value' => 'custom',
+							),
+						),
+					)
+				);
+			}
+
+			$has_restriction_in_use = $has_membership_plans || $has_custom_content_rules;
+
 			$sections['user_registration_content_restriction_settings'] = array(
 				'title'    => __( 'Content Restriction', 'user-registration' ),
 				'type'     => 'card',
-				'settings' => array(
+				'settings' => $has_restriction_in_use ? array(
 					array(
 						'title'                            => __( 'Global Restriction Message', 'user-registration' ),
 						'desc'                             => __( ' Default message for all restricted content.', 'user-registration' ),
@@ -153,15 +181,35 @@ if ( ! class_exists( 'UR_Settings_Membership' ) ) {
 						'show-reset-content-button'        => false,
 						'desc_tip'                         => true,
 					),
-				),
+				) : array(),
 			);
-			$is_new_installation                                        = ur_string_to_bool( get_option( 'urm_is_new_installation', '' ) );
-			if ( ! $is_new_installation ) {
-				$sections['user_registration_content_restriction_settings']['desc'] = sprintf(
-					/* translators: %s - Content rule URL */
-					__( '<strong>The Global Restriction setting has moved.</strong> You can now manage it <a href="%1$s" target="_blank" style="text-decoration: underline;" >here.</a>', 'user-registration' ),
-					esc_url_raw( $content_rule_url )
-				);
+
+			if ( ! $has_restriction_in_use ) {
+				$create_membership_url = admin_url( 'admin.php?page=user-registration-membership&action=add_new_membership' );
+
+				if ( defined( 'UR_PRO_ACTIVE' ) && UR_PRO_ACTIVE && ur_check_module_activation( 'content-restriction' ) ) {
+					$sections['user_registration_content_restriction_settings']['desc'] = sprintf(
+						/* translators: 1: Add new membership URL, 2: Content rule URL */
+						__( '<strong>No membership plans yet.</strong> Restrict content by creating a membership plan or setting up Content Rules. <a href="%1$s">Create a membership &rarr;</a> <a href="%2$s">Set up Content Rules &rarr;</a>', 'user-registration' ),
+						esc_url( $create_membership_url ),
+						esc_url( $content_rule_url )
+					);
+				} else {
+					$sections['user_registration_content_restriction_settings']['desc'] = sprintf(
+						/* translators: %s - Add new membership URL */
+						__( '<strong>No membership plans yet.</strong> Create a membership plan to start restricting content and customize this message. <a href="%s">Create a membership &rarr;</a>', 'user-registration' ),
+						esc_url( $create_membership_url )
+					);
+				}
+			} else {
+				$is_new_installation = ur_string_to_bool( get_option( 'urm_is_new_installation', '' ) );
+				if ( ! $is_new_installation ) {
+					$sections['user_registration_content_restriction_settings']['desc'] = sprintf(
+						/* translators: %s - Content rule URL */
+						__( '<strong>The Global Restriction setting has moved.</strong> You can now manage it <a href="%1$s" target="_blank" style="text-decoration: underline;" >here.</a>', 'user-registration' ),
+						esc_url_raw( $content_rule_url )
+					);
+				}
 			}
 
 			return apply_filters(

--- a/modules/membership/includes/Admin.php
+++ b/modules/membership/includes/Admin.php
@@ -319,6 +319,10 @@ if ( ! class_exists( 'Admin' ) ) :
 		}
 
 		public function add_memberships_in_urcr_settings( $settings ) {
+			if ( empty( $settings['sections']['user_registration_content_restriction_settings']['settings'] ) ) {
+				return $settings;
+			}
+
 			$options             = get_active_membership_id_name();
 			$additional_settings = array(
 				array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

On Settings > Membership > Content Restriction, what shows now depends on the condition:

| Condition | Message shown |
|---|---|
| A membership plan exists, or a custom Content Rule exists | Global Restriction Message editor (unchanged) |
| No membership plan, no custom Content Rule | "No membership plans yet. Create a membership plan to start restricting content and customize this message. **Create a membership →**" |
| No membership plan, no custom Content Rule, but Content Rules is available (Pro) | "No membership plans yet. Restrict content by creating a membership plan or setting up Content Rules. **Create a membership →** **Set up Content Rules →**" |

("Custom Content Rule" = a rule created via Content Rules directly, not one auto-generated per membership plan or migrated from old global-restriction settings.)

Closes #UR-4783.

### How to test the changes in this Pull Request:

1. On a site with no membership plans and no custom Content Rules, open Settings > Membership > Content Restriction and confirm the "Create a membership" message shows instead of the Global Restriction Message field.
2. On a Pro site with the Content Restriction module active, repeat step 1 and confirm the message instead shows both "Create a membership" and "Set up Content Rules" links.
3. Create a membership plan (or a custom Content Rule via Content Rules), reload the tab, and confirm the Global Restriction Message field is back and still saves correctly.
4. Confirm the Settings > Membership tab and the Content Restriction sub-tab remain visible and clickable throughout — only the field/message inside the section changes.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Fix: Hide Content Restriction's Global Restriction Message setting until a membership plan or custom Content Rule exists.