### PR TITLE
UR-4773 Fix - Added site assistant step when registration disabled.

### DIFF
--- a/includes/admin/notifications/class-ur-admin-notices.php
+++ b/includes/admin/notifications/class-ur-admin-notices.php
@@ -60,6 +60,7 @@ class UR_Admin_Notices
 		add_action('admin_init', array(__CLASS__, 'user_registration_install_pages_notice'));
 		add_action('admin_notices', array(__CLASS__, 'php_deprecation_notice'));
 		add_action('admin_init', array(__CLASS__, 'same_membership_in_group'));
+		add_action('admin_notices', array(__CLASS__, 'registration_disabled_notice'));
 
 		/**
 		 * Render Notice with Logo and Buttons.
@@ -773,6 +774,11 @@ class UR_Admin_Notices
 
 				foreach ($wp_filter[$wp_notice]->callbacks as $priority => $hooks) {
 					foreach ($hooks as $name => $arr) {
+						// Always keep the registration disabled notice, it blocks every registration form.
+						if (is_string($name) && false !== strpos($name, 'registration_disabled_notice')) {
+							continue;
+						}
+
 						// Remove all notices if the page is form builder page.
 						if ('add-new-registration' === $_REQUEST['page'] || 'user-registration-dashboard' === $_REQUEST['page']) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 							unset($wp_filter[$wp_notice]->callbacks[$priority][$name]);
@@ -897,6 +903,27 @@ class UR_Admin_Notices
 
 			echo wp_kses_post($notice);
 		}
+	}
+
+	/**
+	 * Notify admins when the WordPress "Anyone can register" option blocks registration.
+	 *
+	 * @since 5.2.7
+	 */
+	public static function registration_disabled_notice()
+	{
+		if (ur_users_can_register() || ! current_user_can('manage_options')) {
+			return;
+		}
+
+		$message = '<strong>' . esc_html__('User Registration & Membership: ', 'user-registration') . '</strong>';
+		$message .= sprintf(
+			/* translators: %1$s - WordPress general settings link. */
+			__('Your registration forms are showing "Registration is currently disabled." because the WordPress <strong>Anyone can register</strong> option is turned off. Enable it in <a href="%1$s">General Settings</a> to let visitors register.', 'user-registration'),
+			esc_url(admin_url('options-general.php#users_can_register'))
+		);
+
+		echo '<div class="notice notice-warning is-dismissible ur-registration-disabled-notice"><p>' . wp_kses_post($message) . '</p></div>';
 	}
 
 	/**

--- a/includes/class-ur-shortcodes.php
+++ b/includes/class-ur-shortcodes.php
@@ -265,18 +265,9 @@ class UR_Shortcodes {
 	 * @param mixed $atts Extra attributes.
 	 */
 	public static function form( $atts ) {
-		/**
-		 * Applies a filter to override the 'users_can_register' setting.
-		 *
-		 * The 'ur_register_setting_override' filter allows developers to customize
-		 * the 'users_can_register' setting by providing an alternative value.
-		 *
-		 * @param bool $default_value Default value retrieved from the 'users_can_register' setting.
-		 */
-		$users_can_register = apply_filters( 'ur_register_setting_override', get_option( 'users_can_register' ) );
-		$check_user_state   = isset( $atts['userState'] ) && 'logged_in' === $atts['userState'];
+		$check_user_state = isset( $atts['userState'] ) && 'logged_in' === $atts['userState'];
 
-		if ( ! is_user_logged_in() && ! $check_user_state && ! $users_can_register ) {
+		if ( ! is_user_logged_in() && ! $check_user_state && ! ur_users_can_register() ) {
 			return apply_filters( 'ur_register_pre_form_message', '<p class="alert" id="ur_register_pre_form_message">' . __( 'Registration is currently disabled.', 'user-registration' ) . '</p>' );
 		}
 

--- a/includes/frontend/class-ur-frontend.php
+++ b/includes/frontend/class-ur-frontend.php
@@ -450,7 +450,7 @@ class UR_Frontend {
 		$is_admin = in_array( 'administrator', (array) $user->roles, true );
 
 		if ( $is_admin ) {
-			echo esc_html_e( 'You do not have any payment records', 'user-registration' );
+			esc_html_e( 'You do not have any payment records', 'user-registration' );
 			return;
 		}
 

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -5652,13 +5652,7 @@ if ( ! function_exists( 'ur_process_registration' ) ) {
 			}
 		}
 
-		/**
-		 * Filter to override the register settings.
-		 * Default value is the get_option('users_can_register')
-		 */
-		$users_can_register = apply_filters( 'ur_register_setting_override', get_option( 'users_can_register' ) );
-
-		if ( ! is_user_logged_in() && ! $users_can_register ) {
+		if ( ! is_user_logged_in() && ! ur_users_can_register() ) {
 			$logger->warning(
 				sprintf( '[Form #%d] Registration is disabled by the site administrator.', $form_id ) . "\n",
 				array(
@@ -8402,6 +8396,23 @@ if ( ! function_exists( 'ur_rsssl_anyone_can_register_conflict_resolver' ) ) {
 }
 add_filter( 'ur_register_setting_override', 'ur_rsssl_anyone_can_register_conflict_resolver', 10, 1 );
 
+if ( ! function_exists( 'ur_users_can_register' ) ) {
+	/**
+	 * Whether registration is allowed, honoring the WordPress "Anyone can register" option.
+	 *
+	 * @since 5.2.7
+	 *
+	 * @return bool
+	 */
+	function ur_users_can_register() {
+		/**
+		 * Filter to override the register settings.
+		 * Default value is the get_option('users_can_register')
+		 */
+		return (bool) apply_filters( 'ur_register_setting_override', get_option( 'users_can_register' ) );
+	}
+}
+
 add_filter( 'user_registration_settings_prevent_default_login', 'ur_prevent_default_login' );
 if ( ! function_exists( 'ur_prevent_default_login' ) ) {
 	/**
@@ -10753,6 +10764,7 @@ if ( ! function_exists( 'ur_get_site_assistant_data' ) ) {
 		}
 
 		$site_assistant_data = array(
+			'users_can_register'                => ur_users_can_register(),
 			'has_default_form'                  => ! empty( $default_form_post ),
 			'missing_pages'                     => $missing_pages_data,
 			'test_email_sent'                   => get_option( 'user_registration_successful_test_mail', false ),
@@ -10991,7 +11003,8 @@ if ( ! function_exists( 'ur_should_show_site_assistant_menu' ) ) {
 		$site_assistant_data = ur_get_site_assistant_data();
 
 		return (
-			! $site_assistant_data['has_default_form']
+			! $site_assistant_data['users_can_register']
+			|| ! $site_assistant_data['has_default_form']
 			|| ! empty( $site_assistant_data['missing_pages'] )
 			|| ! $site_assistant_data['test_email_sent']
 			|| ! $site_assistant_data['spam_protection_handled']
@@ -11012,6 +11025,7 @@ if ( ! function_exists( 'ur_site_assistant_config_count' ) ) {
 		$site_assistant_data = ur_get_site_assistant_data();
 
 		$checks = array(
+			! $site_assistant_data['users_can_register'],
 			! $site_assistant_data['has_default_form'],
 			! empty( $site_assistant_data['missing_pages'] ),
 			! $site_assistant_data['test_email_sent'],

--- a/modules/membership/includes/Admin/Views/member-create.php
+++ b/modules/membership/includes/Admin/Views/member-create.php
@@ -103,7 +103,7 @@ $status_class       = ! empty( $member_subscription ) ? 'user-registration-badge
 						<div class="ur-membership-input-container ur-d-flex ur-p-3" style="gap:20px;">
 							<div class="ur-label">
 								<label
-									for="ur-input-type-membership-email"><?php echo esc_html_e( 'Email', 'user-registration' ); ?>
+									for="ur-input-type-membership-email"><?php esc_html_e( 'Email', 'user-registration' ); ?>
 									<span style="color:red">*</span>
 								</label>
 							</div>

--- a/src/dashboard/screens/SiteAssistant/SiteAssistant.js
+++ b/src/dashboard/screens/SiteAssistant/SiteAssistant.js
@@ -18,6 +18,7 @@ import {
 	DefaultFormMissing,
 	MembershipField,
 	PaymentSetup,
+	RegistrationDisabled,
 	RequiredPagesMissing,
 	SendTestEmail,
 	SpamProtection
@@ -34,6 +35,7 @@ const ticketUrl =
 
 const SiteAssistant = () => {
 	const [open, setOpen] = useState({
+		registrationDisabled: false,
 		defaultForm: false,
 		requiredPages: false,
 		paymentSetup: false,
@@ -41,6 +43,12 @@ const SiteAssistant = () => {
 		spamProtection: false,
 		membershipField: false
 	});
+
+	// Check if the WordPress "Anyone can register" option allows registration
+	const usersCanRegister =
+		typeof _UR_DASHBOARD_ !== "undefined" &&
+		_UR_DASHBOARD_.site_assistant_data &&
+		_UR_DASHBOARD_.site_assistant_data.users_can_register;
 
 	// Check if default form exists
 	const hasDefaultForm =
@@ -156,6 +164,7 @@ const SiteAssistant = () => {
 		(id) => {
 			if (typeof id === "undefined") {
 				const site_config_array = [
+					usersCanRegister,
 					hasDefaultForm,
 					missingPagesData.length === 0,
 					!shouldShowMembershipField,
@@ -165,6 +174,7 @@ const SiteAssistant = () => {
 				];
 
 				const openKeys = [
+					"registrationDisabled",
 					"defaultForm",
 					"requiredPages",
 					"membershipField",
@@ -191,6 +201,7 @@ const SiteAssistant = () => {
 			});
 		},
 		[
+			usersCanRegister,
 			hasDefaultForm,
 			missingPagesData.length,
 			shouldShowMembershipField,
@@ -204,6 +215,7 @@ const SiteAssistant = () => {
 	useEffect(() => {
 		// Check if all components are handled
 		const allComponentsHandled =
+			usersCanRegister &&
 			hasDefaultForm &&
 			missingPagesData.length === 0 &&
 			!shouldShowMembershipField &&
@@ -223,6 +235,7 @@ const SiteAssistant = () => {
 		}
 
 		const site_config_array = [
+			usersCanRegister,
 			hasDefaultForm,
 			missingPagesData.length === 0,
 			!shouldShowMembershipField,
@@ -263,6 +276,7 @@ const SiteAssistant = () => {
 
 		toggleOpen();
 	}, [
+		usersCanRegister,
 		hasDefaultForm,
 		missingPagesData.length,
 		shouldShowMembershipField,
@@ -314,6 +328,15 @@ const SiteAssistant = () => {
 				)}
 				{!allCompleted && (
 					<Stack gap="5">
+						{/* Registration Disabled - only show if WordPress "Anyone can register" is off */}
+						{!usersCanRegister && (
+							<RegistrationDisabled
+								isOpen={open.registrationDisabled}
+								onToggle={() => toggleOpen("registrationDisabled")}
+								numbering={++config_number}
+							/>
+						)}
+
 						{/* Default Form Missing - only show if no default form exists */}
 						{!hasDefaultForm && (
 							<DefaultFormMissing

--- a/src/dashboard/screens/SiteAssistant/components/RegistrationDisabled.js
+++ b/src/dashboard/screens/SiteAssistant/components/RegistrationDisabled.js
@@ -1,0 +1,120 @@
+import {
+	Box,
+	Collapse,
+	Flex,
+	HStack,
+	Heading,
+	Icon,
+	IconButton,
+	Link,
+	Stack,
+	Text
+} from "@chakra-ui/react";
+import { __ } from "@wordpress/i18n";
+import React from "react";
+import { BiChevronDown, BiChevronUp } from "react-icons/bi";
+
+const RegistrationDisabled = ({ isOpen, onToggle, numbering }) => {
+	const handleConfigureGeneralSettings = () => {
+		const adminURL =
+			window._UR_DASHBOARD_?.adminURL ||
+			`${window.location.origin}/wp-admin/`;
+		window.open(
+			`${adminURL}options-general.php#users_can_register`,
+			"_blank"
+		);
+	};
+
+	return (
+		<Stack
+			p="6"
+			gap="5"
+			bgColor="white"
+			borderRadius="base"
+			border="1px"
+			borderColor="gray.100"
+		>
+			<HStack
+				justify={"space-between"}
+				onClick={onToggle}
+				borderBottom={isOpen && "1px solid #dcdcde"}
+				paddingBottom={isOpen && 5}
+				_hover={{
+					cursor: "pointer"
+				}}
+			>
+				<Heading
+					as="h3"
+					fontSize="18px"
+					fontWeight="semibold"
+					lineHeight={"1.2"}
+				>
+					{numbering +
+						") " +
+						__("Registration Is Disabled", "user-registration")}
+				</Heading>
+				<IconButton
+					aria-label={"registrationDisabled"}
+					icon={
+						<Icon
+							as={isOpen ? BiChevronUp : BiChevronDown}
+							fontSize="2xl"
+							fill={isOpen ? "primary.500" : "black"}
+						/>
+					}
+					cursor={"pointer"}
+					fontSize={"xl"}
+					size="sm"
+					boxShadow="none"
+					borderRadius="base"
+					variant={isOpen ? "solid" : "link"}
+					border="none"
+				/>
+			</HStack>
+			<Collapse in={isOpen}>
+				<Stack gap={5}>
+					<Text fontWeight={"light"} fontSize={"15px !important"}>
+						{__(
+							'Your registration forms show "Registration is currently disabled." because the WordPress "Anyone can register" option is turned off.',
+							"user-registration"
+						)}
+					</Text>
+
+					<Flex
+						bg="#f9fafc"
+						p="4"
+						borderRadius="md"
+						justify="space-between"
+						align="center"
+					>
+						<Box>
+							<Text
+								fontSize={"15px !important"}
+								fontWeight="bold"
+								mb={1}
+							>
+								{__("Anyone can register", "user-registration")}
+							</Text>
+							<Text fontSize="14px" color="gray.600">
+								{__(
+									"Enable membership registration in WordPress General Settings",
+									"user-registration"
+								)}
+							</Text>
+						</Box>
+						<Link
+							color="primary.500"
+							textDecoration="underline"
+							onClick={handleConfigureGeneralSettings}
+							cursor="pointer"
+						>
+							{__("Configure Settings", "user-registration")}
+						</Link>
+					</Flex>
+				</Stack>
+			</Collapse>
+		</Stack>
+	);
+};
+
+export default RegistrationDisabled;

--- a/src/dashboard/screens/SiteAssistant/components/index.js
+++ b/src/dashboard/screens/SiteAssistant/components/index.js
@@ -1,3 +1,4 @@
+export { default as RegistrationDisabled } from './RegistrationDisabled';
 export { default as DefaultFormMissing } from './DefaultFormMissing';
 export { default as RequiredPagesMissing } from './RequiredPagesMissing';
 export { default as PaymentSetup } from './PaymentSetup';

--- a/templates/myaccount/membership.php
+++ b/templates/myaccount/membership.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( empty( $membership_data ) ) {
-	echo esc_html_e( 'You do not have any records', 'user-registration' );
+	esc_html_e( 'You do not have any records', 'user-registration' );
 	return;
 }
 

--- a/templates/myaccount/payments.php
+++ b/templates/myaccount/payments.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( empty( $orders ) || empty( $orders['items'] ) ) {
-	echo esc_html_e( 'You do not have any payment records', 'user-registration' );
+	esc_html_e( 'You do not have any payment records', 'user-registration' );
 	return;
 }
 

--- a/templates/myaccount/team.php
+++ b/templates/myaccount/team.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( empty( $teams ) || empty( $teams['items'] ) ) {
-	echo esc_html_e( 'You do not have any team records', 'user-registration' );
+	esc_html_e( 'You do not have any team records', 'user-registration' );
 	return;
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Added  site assistant step if admin has disabled anyone can register.

Closes # .

### How to test the changes in this Pull Request:

1. Disabled Anyone can register.
2. Site assistant must show the section to enable it.
3. Enmable and verify it it disapears from site assistant or not.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Added site assistant step when registration disabled.
