### PR TITLE
UR-4767 - Fix - Disable emails setting not blocking all emails

### DIFF
--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -94,6 +94,7 @@ class UR_AJAX {
 			'create_default_form'                  => false,
 			'generate_required_pages'              => false,
 			'handle_default_wordpress_login'       => false,
+			'enable_emails'                        => false,
 			'skip_site_assistant_section'          => false,
 			'login_settings_page_validation'       => false,
 			'activate_dependent_module'            => false,
@@ -2611,6 +2612,25 @@ class UR_AJAX {
 		} else {
 			wp_send_json_error( array( 'message' => __( 'Invalid action specified.', 'user-registration' ) ) );
 		}
+	}
+
+	/**
+	 * Turn the master "Disable emails" setting back off.
+	 */
+	public static function enable_emails() {
+		check_ajax_referer( 'wp_rest', 'security' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( 'You do not have permission to modify email settings.', 'user-registration' ) ) );
+		}
+
+		update_option( 'user_registration_email_setting_disable_email', 'no' );
+
+		wp_send_json_success(
+			array(
+				'message' => __( 'Emails have been enabled successfully.', 'user-registration' ),
+			)
+		);
 	}
 
 	/**

--- a/includes/class-ur-emailer.php
+++ b/includes/class-ur-emailer.php
@@ -97,13 +97,14 @@ class UR_Emailer {
 	 * @return void
 	 */
 	public static function ur_after_register_mail( $valid_form_data, $form_id, $user_id ) {
+		if ( ur_option_checked( 'user_registration_email_setting_disable_email' ) ) {
+			return;
+		}
+
 		$valid_form_data = ur_array_clone( $valid_form_data );
 
 		$login_option = ur_get_user_login_option( $user_id );
 
-		if ( ( 'email_confirmation' !== $login_option || 'admin_approval_after_email_confirmation' !== $login_option ) && ur_option_checked( 'user_registration_email_setting_disable_email' ) ) {
-			return;
-		}
 		/**
 		 * Hook to modify user email attachment.
 		 *
@@ -294,6 +295,11 @@ class UR_Emailer {
 	public static function user_registration_process_and_send_email( $email, $subject, $message, $header, $attachment, $template_id ) {
 
 		$logger = ur_get_logger();
+
+		if ( ur_option_checked( 'user_registration_email_setting_disable_email' ) ) {
+			$logger->notice( 'Email not sent: emails are disabled from email settings.', array( 'source' => 'ur_mail_logs' ) );
+			return true;
+		}
 		$logger->notice( '=============== Email Sending Start ================', array( 'source' => 'ur_mail_logs' ) );
 		$logger->debug(
 			'Email details:' . "\n" . wp_json_encode(
@@ -564,9 +570,6 @@ class UR_Emailer {
 	 */
 	public static function ur_profile_details_changed_mail( $user_id, $form_id ) {
 
-		if ( ur_option_checked( 'user_registration_email_setting_disable_email' ) ) {
-			return;
-		}
 		$profile      = user_registration_form_data( $user_id, $form_id );
 		$name_value   = array();
 		$data_html    = '<table class="user-registration-email__entries" cellpadding="0" cellspacing="0"><tbody>';

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -10755,6 +10755,7 @@ if ( ! function_exists( 'ur_get_site_assistant_data' ) ) {
 		$site_assistant_data = array(
 			'has_default_form'                  => ! empty( $default_form_post ),
 			'missing_pages'                     => $missing_pages_data,
+			'disabled_emails_handled'           => ! ur_option_checked( 'user_registration_email_setting_disable_email' ),
 			'test_email_sent'                   => get_option( 'user_registration_successful_test_mail', false ),
 			'spam_protection_handled'           => ur_string_to_bool( get_option( 'user_registration_captcha_setting_v2_connection_status', false ) ) || ur_string_to_bool( get_option( 'user_registration_spam_protection_skipped', false ) ),
 			'payment_setup_handled'             => $payment_setup_handled,
@@ -10993,6 +10994,7 @@ if ( ! function_exists( 'ur_should_show_site_assistant_menu' ) ) {
 		return (
 			! $site_assistant_data['has_default_form']
 			|| ! empty( $site_assistant_data['missing_pages'] )
+			|| ! $site_assistant_data['disabled_emails_handled']
 			|| ! $site_assistant_data['test_email_sent']
 			|| ! $site_assistant_data['spam_protection_handled']
 			|| ! $site_assistant_data['payment_setup_handled']
@@ -11014,6 +11016,7 @@ if ( ! function_exists( 'ur_site_assistant_config_count' ) ) {
 		$checks = array(
 			! $site_assistant_data['has_default_form'],
 			! empty( $site_assistant_data['missing_pages'] ),
+			! $site_assistant_data['disabled_emails_handled'],
 			! $site_assistant_data['test_email_sent'],
 			! $site_assistant_data['spam_protection_handled'],
 			! $site_assistant_data['payment_setup_handled'],

--- a/modules/membership/includes/Admin/Services/EmailService.php
+++ b/modules/membership/includes/Admin/Services/EmailService.php
@@ -381,7 +381,7 @@ class EmailService {
 		$message = apply_filters( 'ur_membership_payment_successful_email_custom_template', $message, $subject );
 		$headers = \UR_Emailer::ur_get_header();
 
-		return wp_mail( $data['user_email'], $subject, $message, $headers );
+		return \UR_Emailer::user_registration_process_and_send_email( $data['user_email'], $subject, $message, $headers, array(), 0 );
 	}
 	// **
 	// * Send payment successful email
@@ -695,6 +695,6 @@ class EmailService {
 		$message = apply_filters( 'ur_membership_registration_email_custom_template', $message, $subject );
 		$headers = \UR_Emailer::ur_get_header();
 
-		return wp_mail( $data['email'], $subject, $message, $headers );
+		return \UR_Emailer::user_registration_process_and_send_email( $data['email'], $subject, $message, $headers, array(), 0 );
 	}
 }

--- a/src/dashboard/screens/SiteAssistant/SiteAssistant.js
+++ b/src/dashboard/screens/SiteAssistant/SiteAssistant.js
@@ -16,6 +16,7 @@ import * as URIcon from "../../components/Icon/Icon";
 // Import new components
 import {
 	DefaultFormMissing,
+	DisabledEmails,
 	MembershipField,
 	PaymentSetup,
 	RequiredPagesMissing,
@@ -37,6 +38,7 @@ const SiteAssistant = () => {
 		defaultForm: false,
 		requiredPages: false,
 		paymentSetup: false,
+		disabledEmails: false,
 		sendTestEmail: false,
 		spamProtection: false,
 		membershipField: false
@@ -55,6 +57,17 @@ const SiteAssistant = () => {
 		_UR_DASHBOARD_.site_assistant_data.missing_pages
 			? _UR_DASHBOARD_.site_assistant_data.missing_pages
 			: [];
+
+	// Check if the disabled emails notice is already handled (enabled or skipped)
+	const initialDisabledEmailsHandled =
+		typeof _UR_DASHBOARD_ === "undefined" ||
+		!_UR_DASHBOARD_.site_assistant_data ||
+		_UR_DASHBOARD_.site_assistant_data.disabled_emails_handled !== false;
+
+	// State to track if the disabled emails notice was handled during this session
+	const [disabledEmailsHandled, setDisabledEmailsHandled] = useState(
+		initialDisabledEmailsHandled
+	);
 
 	// Check if test email was already sent successfully
 	const initialTestEmailSent =
@@ -131,6 +144,11 @@ const SiteAssistant = () => {
 	// State to track if all components are completed
 	const [allCompleted, setAllCompleted] = useState(false);
 
+	// Callback to handle when emails are enabled or the notice is skipped
+	const handleDisabledEmailsHandled = useCallback(() => {
+		setDisabledEmailsHandled(true);
+	}, []);
+
 	// Callback to handle when test email is sent successfully
 	const handleTestEmailSent = useCallback(() => {
 		setTestEmailSent(true);
@@ -160,6 +178,7 @@ const SiteAssistant = () => {
 					missingPagesData.length === 0,
 					!shouldShowMembershipField,
 					paymentSetupHandled,
+					disabledEmailsHandled,
 					testEmailSent,
 					spamProtectionHandled
 				];
@@ -169,6 +188,7 @@ const SiteAssistant = () => {
 					"requiredPages",
 					"membershipField",
 					"paymentSetup",
+					"disabledEmails",
 					"sendTestEmail",
 					"spamProtection"
 				];
@@ -195,6 +215,7 @@ const SiteAssistant = () => {
 			missingPagesData.length,
 			shouldShowMembershipField,
 			paymentSetupHandled,
+			disabledEmailsHandled,
 			testEmailSent,
 			spamProtectionHandled
 		]
@@ -207,6 +228,7 @@ const SiteAssistant = () => {
 			hasDefaultForm &&
 			missingPagesData.length === 0 &&
 			!shouldShowMembershipField &&
+			disabledEmailsHandled &&
 			testEmailSent &&
 			spamProtectionHandled &&
 			paymentSetupHandled;
@@ -226,6 +248,7 @@ const SiteAssistant = () => {
 			hasDefaultForm,
 			missingPagesData.length === 0,
 			!shouldShowMembershipField,
+			disabledEmailsHandled,
 			testEmailSent,
 			spamProtectionHandled,
 			paymentSetupHandled
@@ -266,6 +289,7 @@ const SiteAssistant = () => {
 		hasDefaultForm,
 		missingPagesData.length,
 		shouldShowMembershipField,
+		disabledEmailsHandled,
 		testEmailSent,
 		spamProtectionHandled,
 		paymentSetupHandled,
@@ -349,6 +373,16 @@ const SiteAssistant = () => {
 								isOpen={open.paymentSetup}
 								onToggle={() => toggleOpen("paymentSetup")}
 								onSkipped={handlePaymentSetupHandled}
+								numbering={++config_number}
+							/>
+						)}
+
+						{/* Emails Disabled - only show while the master disable setting is on */}
+						{!disabledEmailsHandled && (
+							<DisabledEmails
+								isOpen={open.disabledEmails}
+								onToggle={() => toggleOpen("disabledEmails")}
+								onHandled={handleDisabledEmailsHandled}
 								numbering={++config_number}
 							/>
 						)}

--- a/src/dashboard/screens/SiteAssistant/components/DisabledEmails.js
+++ b/src/dashboard/screens/SiteAssistant/components/DisabledEmails.js
@@ -1,0 +1,199 @@
+import {
+	Box,
+	Collapse,
+	Flex,
+	FormControl,
+	FormLabel,
+	HStack,
+	Heading,
+	Icon,
+	IconButton,
+	Link,
+	Stack,
+	Switch,
+	Text,
+	useToast
+} from "@chakra-ui/react";
+import { __ } from "@wordpress/i18n";
+import { useState } from "react";
+import { BiChevronDown, BiChevronUp } from "react-icons/bi";
+
+const DisabledEmails = ({ isOpen, onToggle, onHandled, numbering }) => {
+	const [isEnabling, setIsEnabling] = useState(false);
+	const toast = useToast();
+
+	const handleEmailSettings = () => {
+		const settingsURL =
+			window._UR_DASHBOARD_?.settingsURL ||
+			`${window.location.origin}/wp-admin/admin.php?page=user-registration-settings`;
+		window.open(`${settingsURL}&tab=email`, "_blank");
+	};
+
+	const handleEnableEmails = async (checked) => {
+		if (!checked) {
+			return;
+		}
+
+		setIsEnabling(true);
+
+		try {
+			const adminURL =
+				window._UR_DASHBOARD_?.adminURL ||
+				window.location.origin + "/wp-admin";
+			const response = await fetch(`${adminURL}admin-ajax.php`, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/x-www-form-urlencoded"
+				},
+				body: new URLSearchParams({
+					action: "user_registration_enable_emails",
+					security: window._UR_DASHBOARD_?.urRestApiNonce || ""
+				})
+			});
+
+			const result = await response.json();
+
+			if (!result.success) {
+				throw new Error(
+					result.data?.message ||
+						__("Failed to enable emails.", "user-registration")
+				);
+			}
+
+			toast({
+				title: __("Emails Enabled", "user-registration"),
+				description:
+					result.data?.message ||
+					__(
+						"Emails have been enabled successfully.",
+						"user-registration"
+					),
+				status: "success",
+				duration: 3000,
+				isClosable: true
+			});
+
+			if (onHandled) {
+				onHandled();
+			}
+		} catch (error) {
+			toast({
+				title: __("Error", "user-registration"),
+				description:
+					error.message ||
+					__(
+						"Failed to enable emails. Please try again.",
+						"user-registration"
+					),
+				status: "error",
+				duration: 3000,
+				isClosable: true
+			});
+		} finally {
+			setIsEnabling(false);
+		}
+	};
+
+	return (
+		<Stack
+			p="6"
+			gap="5"
+			bgColor="white"
+			borderRadius="base"
+			border="1px"
+			borderColor="gray.100"
+		>
+			<HStack
+				justify={"space-between"}
+				onClick={onToggle}
+				borderBottom={isOpen && "1px solid #dcdcde"}
+				paddingBottom={isOpen && 5}
+				_hover={{
+					cursor: "pointer"
+				}}
+			>
+				<Heading
+					as="h3"
+					fontSize="18px"
+					fontWeight="semibold"
+					lineHeight={"1.2"}
+				>
+					{numbering + ") " + __("Emails Disabled", "user-registration")}
+				</Heading>
+				<IconButton
+					aria-label={"disabledEmails"}
+					icon={
+						<Icon
+							as={isOpen ? BiChevronUp : BiChevronDown}
+							fontSize="2xl"
+							fill={isOpen ? "primary.500" : "black"}
+						/>
+					}
+					cursor={"pointer"}
+					fontSize={"xl"}
+					size="sm"
+					boxShadow="none"
+					borderRadius="base"
+					variant={isOpen ? "solid" : "link"}
+					border="none"
+				/>
+			</HStack>
+			<Collapse in={isOpen}>
+				<Stack gap={5}>
+					<Text fontWeight={"light"} fontSize={"15px !important"}>
+						{__(
+							"The Disable emails setting is turned on, so no emails are sent to your users or admins. Registration confirmation, admin approval and membership emails are all affected.",
+							"user-registration"
+						)}
+					</Text>
+					<FormControl bg="#f9fafc" p="4" borderRadius="md">
+						<Flex justify="space-between" align="center">
+							<Box>
+								<FormLabel
+									fontSize={"15px !important"}
+									fontWeight="medium"
+									mb={1}
+								>
+									{__("Enable Emails", "user-registration")}
+								</FormLabel>
+								<Text color="gray.600">
+									{isEnabling
+										? __("Enabling...", "user-registration")
+										: __(
+												"Turns off the Disable emails setting",
+												"user-registration"
+											)}
+								</Text>
+							</Box>
+							<Switch
+								isChecked={false}
+								isDisabled={isEnabling}
+								onChange={(e) =>
+									handleEnableEmails(e.target.checked)
+								}
+								colorScheme="primary"
+							/>
+						</Flex>
+					</FormControl>
+					<Text color="gray.600" fontSize="14px">
+						{__(
+							"You can also manage this from ",
+							"user-registration"
+						)}
+						<Link
+							color="primary.500"
+							textDecoration="underline"
+							onClick={handleEmailSettings}
+							cursor="pointer"
+						>
+							{__("Email Settings", "user-registration")}
+						</Link>
+						.
+					</Text>
+				</Stack>
+			</Collapse>
+		</Stack>
+	);
+};
+
+export default DisabledEmails;

--- a/src/dashboard/screens/SiteAssistant/components/index.js
+++ b/src/dashboard/screens/SiteAssistant/components/index.js
@@ -1,6 +1,7 @@
 export { default as DefaultFormMissing } from './DefaultFormMissing';
 export { default as RequiredPagesMissing } from './RequiredPagesMissing';
 export { default as PaymentSetup } from './PaymentSetup';
+export { default as DisabledEmails } from './DisabledEmails';
 export { default as SendTestEmail } from './SendTestEmail';
 export { default as SpamProtection } from './SpamProtection';
 export { default as MembershipField } from './MembershipField';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

**Problem:** "Disable emails" only guarded two registration hooks, so every other email (membership, approval, confirmation, password reset, custom) still sent.

**Fix:** Moved the guard into the shared email sender so all senders are covered from one place, routed two raw `wp_mail()` membership calls through it, and added a Site Assistant section with a toggle to re-enable emails.

Closes # .

### How to test the changes in this Pull Request:

**Test steps**

1. Settings > Emails > General, turn **Disable emails** on.
2. Register a new user on the frontend — no user email, no admin email.
3. Repeat with the form's login option set to Email Confirmation, then Admin Approval — still nothing sent.
4. Buy/assign a membership plan — no membership or payment email.
5. Edit profile, change email, request lost password — nothing sent.
6. Check the mail log (`ur_mail_logs`) shows "Email not sent: emails are disabled from email settings."
7. Confirm **Send Test Email** still works (should send, by design).
8. Turn the setting off, repeat steps 2-5 — each scenario sends its expected email again, and per-email toggles still apply.

**Site Assistant**

9. With the setting on, open Site Assistant — "Emails Disabled" section appears, submenu badge count includes it.
10. Flip the toggle — success toast, section disappears, badge drops, and Settings > Emails shows Disable emails now off.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Disable emails setting not blocking all emails.
