### PR TITLE
UR-4769 Fix - Show emails only when respective settings are enabled.

### DIFF
--- a/modules/membership/includes/Admin/Services/EmailService.php
+++ b/modules/membership/includes/Admin/Services/EmailService.php
@@ -308,8 +308,14 @@ class EmailService {
 		);
 		$values               = $data + $values;
 
+		$email_classes = apply_filters( 'user_registration_email_classes', array() );
+
+		if ( ! isset( $email_classes['UR_Settings_Payment_Retry_Failed_Email'] ) ) {
+			return;
+		}
+
 		$subject  = __( 'Payment Attempt Failed – Action Required on {{blog_info}}', 'user-registration' );
-		$settings = new \UR_Settings_Payment_Retry_Failed_Email();
+		$settings = $email_classes['UR_Settings_Payment_Retry_Failed_Email'];
 		$message  = $settings->ur_get_payment_retry_failed_email();
 		$message  = get_option( 'user_registration_payment_retry_failed_email', $message );
 		$message  = \UR_Emailer::parse_smart_tags( $message, $values );
@@ -338,8 +344,14 @@ class EmailService {
 		);
 		$values               = $data + $values;
 
+		$email_classes = apply_filters( 'user_registration_email_classes', array() );
+
+		if ( ! isset( $email_classes['UR_Settings_Payment_Retry_Cancel_Email'] ) ) {
+			return;
+		}
+
 		$subject  = __( 'Payment Cancelled – Registration Cancelled on {{blog_info}}', 'user-registration' );
-		$settings = new \UR_Settings_Payment_Retry_Cancel_Email();
+		$settings = $email_classes['UR_Settings_Payment_Retry_Cancel_Email'];
 		$message  = $settings->ur_get_payment_retry_cancel_email();
 		$message  = get_option( 'user_registration_payment_retry_cancel_email', $message );
 		$message  = \UR_Emailer::parse_smart_tags( $message, $values );

--- a/modules/membership/includes/Emails/EmailSettings.php
+++ b/modules/membership/includes/Emails/EmailSettings.php
@@ -2,6 +2,7 @@
 
 namespace WPEverest\URMembership\Emails;
 
+use WPEverest\URMembership\Admin\Repositories\MembershipRepository;
 use WPEverest\URMembership\Admin\Services\SubscriptionService;
 use WPEverest\URMembership\Emails\Admin\UR_Settings_Membership_Cancellation_Admin_Email;
 use WPEverest\URMembership\Emails\User\UR_Settings_Membership_Cancellation_User_Email;
@@ -28,14 +29,26 @@ class EmailSettings {
 	 * @return array
 	 */
 	public function add_email_settings( $emails ) {
+		if ( empty( ( new MembershipRepository() )->get_all_membership() ) ) {
+			return $emails;
+		}
+
 		$new_emails = array(
 			'UR_Settings_Membership_Cancellation_Admin_Email'    => new UR_Settings_Membership_Cancellation_Admin_Email(),
 			'UR_Settings_Membership_Cancellation_User_Email'     => new UR_Settings_Membership_Cancellation_User_Email(),
 		);
 
 		if ( UR_PRO_ACTIVE ) {
-			$new_emails['UR_Settings_Membership_Renewal_Reminder_User_Email'] = new UR_Settings_Membership_Renewal_Reminder_User_Email();
-			$new_emails['UR_Settings_Membership_Expiring_Soon_User_Email'] = new UR_Settings_Membership_Expiring_Soon_User_Email();
+			$renewal_behaviour = get_option( 'user_registration_renewal_behaviour', 'automatic' );
+
+			if ( 'automatic' === $renewal_behaviour ) {
+				$new_emails['UR_Settings_Membership_Renewal_Reminder_User_Email'] = new UR_Settings_Membership_Renewal_Reminder_User_Email();
+			}
+
+			if ( 'manual' === $renewal_behaviour ) {
+				$new_emails['UR_Settings_Membership_Expiring_Soon_User_Email'] = new UR_Settings_Membership_Expiring_Soon_User_Email();
+			}
+
 			$new_emails['UR_Settings_Membership_Ended_User_Email'] = new UR_Settings_Membership_Ended_User_Email();
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Membership emails were listed under Settings → Emails even when they could never be
sent, which is misleading for admins and QA. This PR gates their registration on the
settings that actually control them.

`modules/membership/includes/Emails/EmailSettings.php`

- Registers no membership emails at all when the site has no published membership.
  The check goes through `MembershipRepository::get_all_membership()` rather than a new
  query, matching the existing usage in `MembershipService` and `Subscriptions`.
- Renewal Reminder is registered only when `user_registration_renewal_behaviour` is
  `automatic`.
- Expiring Soon is registered only when `user_registration_renewal_behaviour` is
  `manual`.
- Membership Ended and both Cancellation emails are unchanged beyond the membership
  existence gate.

`modules/membership/includes/Admin/Services/EmailService.php`

- `send_payment_retry_failed_email()` and `send_payment_retry_cancel_email()` called
  `new \UR_Settings_Payment_Retry_*_Email()` directly. Those classes are only loaded by
  the `user_registration_email_classes` filter on admin settings pages, so a cron-time
  send had no class at all, and on the free plugin the class never exists. Both methods
  now resolve the instance from the filter and return early when it is absent.

Because the settings list, the configure/save route and the email preview all read the
same `user_registration_email_classes` filter, gating registration hides the row, makes
the configure section empty and makes the preview URL report the email as unavailable,
with no separate change in those three places.

### How to test the changes in this Pull Request:

1. On a site with no membership created, go to Settings → Emails → To User and To Admin.
   No membership emails are listed. Create a membership, reload, and they appear.
2. Set Settings → Membership → Renewal Behaviour to Renew Automatically. Membership
   Renewal Reminder is listed and Membership Expiring Soon is not.
3. Switch Renewal Behaviour to Renew Manually. The two swap.
4. Open the preview URL of a hidden email directly
   (`?ur_email_preview=membership_expiring_soon_user_email`). It reports that the email
   does not exist instead of rendering.
5. Confirm no regression for Cancellation, Ended, Payment Pending, Payment Success,
   Delete Account and Passwordless Login emails.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Fix - Show emails only when respective settings are enabled.