### PR TITLE
UR-4776 Fix - Renewal Reminder and Expiring Soon emails both sent regardless of renewal behaviour.

### DIFF
--- a/modules/membership/includes/Admin/Services/EmailService.php
+++ b/modules/membership/includes/Admin/Services/EmailService.php
@@ -588,6 +588,11 @@ class EmailService {
 	}
 
 	public function send_membership_renewal_email( $data ) {
+		// Renewal reminder only applies to automatic renewal; manual sites get the expiring soon email instead.
+		if ( 'automatic' !== get_option( 'user_registration_renewal_behaviour', 'automatic' ) ) {
+			return false;
+		}
+
 		$subject = get_option( 'user_registration_membership_renewal_reminder_user_email_subject', esc_html__( 'Your Membership Renews Soon', 'user-registration' ) );
 		$user    = get_userdata( $data['member_id'] );
 
@@ -609,6 +614,11 @@ class EmailService {
 	}
 
 	public function send_membership_expiring_soon_email( $data ) {
+		// Expiring soon only applies to manual renewal; automatic sites get the renewal reminder email instead.
+		if ( 'manual' !== get_option( 'user_registration_renewal_behaviour', 'automatic' ) ) {
+			return false;
+		}
+
 		$subject = get_option( 'user_registration_membership_expiring_soon_user_email_subject', esc_html__( 'Your Membership Expires on {{membership_end_date}}', 'user-registration' ) );
 
 		$form_id              = ur_get_form_id_by_userid( $data['member_id'] );

--- a/modules/membership/includes/Crons.php
+++ b/modules/membership/includes/Crons.php
@@ -55,7 +55,7 @@ class Crons {
 	 * @return void
 	 */
 	public function membership_renewal_check() {
-		if ( ! ur_option_checked( 'user_registration_membership_enable_renewal_reminder_user_email', false ) && 'automatic' !== get_option( 'user_registration_renewal_behaviour', 'automatic' ) ) {
+		if ( ! ur_option_checked( 'user_registration_membership_enable_renewal_reminder_user_email', true ) || 'automatic' !== get_option( 'user_registration_renewal_behaviour', 'automatic' ) ) {
 			return;
 		}
 		$subscription_service = new SubscriptionService();
@@ -69,7 +69,7 @@ class Crons {
 	 */
 	public function membership_expiring_soon_check() {
 
-		if ( ! ur_option_checked( 'user_registration_membership_enable_expiring_soon_user_email', false ) && 'manual' !== get_option( 'user_registration_renewal_behaviour', 'automatic' ) ) {
+		if ( ! ur_option_checked( 'user_registration_membership_enable_expiring_soon_user_email', true ) || 'manual' !== get_option( 'user_registration_renewal_behaviour', 'automatic' ) ) {
 			return;
 		}
 

--- a/modules/membership/includes/Emails/EmailSettings.php
+++ b/modules/membership/includes/Emails/EmailSettings.php
@@ -34,8 +34,12 @@ class EmailSettings {
 		);
 
 		if ( UR_PRO_ACTIVE ) {
-			$new_emails['UR_Settings_Membership_Renewal_Reminder_User_Email'] = new UR_Settings_Membership_Renewal_Reminder_User_Email();
-			$new_emails['UR_Settings_Membership_Expiring_Soon_User_Email'] = new UR_Settings_Membership_Expiring_Soon_User_Email();
+			// Only the reminder matching the site's renewal behaviour is listed; the other stays registered nowhere so its saved content is untouched.
+			if ( 'automatic' === get_option( 'user_registration_renewal_behaviour', 'automatic' ) ) {
+				$new_emails['UR_Settings_Membership_Renewal_Reminder_User_Email'] = new UR_Settings_Membership_Renewal_Reminder_User_Email();
+			} else {
+				$new_emails['UR_Settings_Membership_Expiring_Soon_User_Email'] = new UR_Settings_Membership_Expiring_Soon_User_Email();
+			}
 			$new_emails['UR_Settings_Membership_Ended_User_Email'] = new UR_Settings_Membership_Ended_User_Email();
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Show only required email for either manual or automatic renewal email.

Closes # .

### How to test the changes in this Pull Request:

## UI test steps

1. **Settings > Membership > General** — set Renewal Behaviour to **Renew Automatically**. Save.
2. **Settings > Emails > To User** — expect **Membership Renewal Reminder** in list, **Membership Expiring Soon** gone.
3. Open Renewal Reminder, change subject to `TEST 123`. Save.
4. Back to **Membership > General** — switch to **Renew Manually**. Save.
5. **Emails > To User** — expect **Membership Expiring Soon** listed, **Renewal Reminder** gone.
6. Switch back to **Renew Automatically**, open Renewal Reminder — subject still `TEST 123`.

Membership Ended must stay listed in both modes.

**Send check** needs cron. Install WP Crontrol, set the reminder day count to exactly match an active subscription's next billing date offset, then run `urm_daily_membership_renewal_check` and `urm_daily_membership_expiring_soon_check` from **Tools > Cron Events**. Expect one email, matching the mode.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Renewal Reminder and Expiring Soon emails both sent regardless of renewal behaviour.
