### PR TITLE
UR-4798 Fix - False success message on profile update for non-UR-form users

### DIFF
--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -273,7 +273,16 @@ class UR_AJAX {
 			}
 		}
 
-		$profile                        = user_registration_form_data( $user_id, $form_id );
+		$profile = user_registration_form_data( $user_id, $form_id );
+
+		if ( empty( $profile ) ) {
+			wp_send_json_error(
+				array(
+					'message' => __( 'Unable to update profile. No editable profile fields were found for this account.', 'user-registration' ),
+				)
+			);
+		}
+
 		$is_admin_user                  = $_POST['is_admin_user'] ?? false;
 		list( $profile, $single_field ) = urm_process_profile_fields( $profile, $single_field, $form_data, $form_id, $user_id, $is_admin_user );
 		$user                           = get_userdata( $user_id );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

https://themegrill.atlassian.net/browse/UR-4798

Users who were never registered through a UR form (created via WooCommerce checkout or wp-admin, `ur_form_id` unresolved / `-1`) could not update any field from My Account → Profile Details, yet the UI showed "User profile updated successfully" as if the save had worked.

Root cause: `user_registration_form_data( $user_id, $form_id )` returns an empty array when `$form_id` doesn't resolve to a real `user_registration` form post. In `urm_update_user_profile_data()`, the entire save routine is a `foreach ( $profile as ... )` loop, so an empty `$profile` means the loop body never runs — nothing is written to the database. `update_profile_details()` in `includes/class-ur-ajax.php`, however, unconditionally returned `wp_send_json_success()` regardless of whether that loop did anything.

Fix: right after `$profile` is resolved, if it's empty the handler now returns `wp_send_json_error()` with a clear message instead of falling through to the no-op save + false success response. This only changes the response message for this specific case — no write path (`update_user_meta`, `wp_update_user`) is touched, and no data is deleted or modified differently than before.

Note: the ticket's "Expected Behavior" also proposes falling back to a valid registration form so the save can still succeed. That's a larger, separate change (it would alter what actually gets written for these users) and isn't included here — this PR only fixes the false-success message. Flagging for reviewer input on whether the fallback should be scoped as a follow-up.

Closes # .

### How to test the changes in this Pull Request:

1. Create a user with no resolvable `ur_form_id` — e.g. via wp-admin Users → Add New, or a WooCommerce-checkout-created customer.
2. Log in as that user and go to My Account → Profile Details (renders the non-UR-form fallback template with Username/First Name/Email/Last Name).
3. Change a field (e.g. First Name) and save.
   - Before: "User profile updated successfully" shown, but reloading the page shows the field was never actually saved.
   - After: an error message is shown ("Unable to update profile. No editable profile fields were found for this account."), accurately reflecting that nothing was saved.
4. Confirm a normal user with a valid UR form still saves and shows success as before (no regression).

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Fix - False success shown when profile update saves nothing.
