### PR TITLE
UR-4810 Fix fatal error: array_key_exists() receives null instead of array in form validation during subscription registration

### DIFF
--- a/includes/frontend/class-ur-frontend-form-handler.php
+++ b/includes/frontend/class-ur-frontend-form-handler.php
@@ -60,6 +60,10 @@ class UR_Frontend_Form_Handler {
 			)
 		);
 
+		// Reset per-submission static state so a prior request can't leak stale data into this one (e.g. on persistent PHP workers).
+		self::$response_array  = array();
+		self::$valid_form_data = array();
+
 		self::$form_id      = $form_id;
 		$post_content_array = ( $form_id ) ? UR()->form->get_form( $form_id, array( 'content_only' => true ) ) : array();
 

--- a/includes/validation/class-ur-form-validation.php
+++ b/includes/validation/class-ur-form-validation.php
@@ -68,6 +68,10 @@ class UR_Form_Validation extends UR_Validation {
 	 * @return array
 	 */
 	public function reorganize_form_data( $valid_form_data, $form_field_data, $form_id ) {
+		if ( ! is_array( $valid_form_data ) ) {
+			$valid_form_data = array();
+		}
+
 		if ( empty( $form_field_data ) ) {
 			return $valid_form_data;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Registration was fataling on submit for a customer's subscription/membership registration form (reported via a live error log):

```
Uncaught TypeError: array_key_exists(): Argument #2 ($array) must be of type array, null given in
includes/validation/class-ur-form-validation.php:98
```

`UR_Frontend_Form_Handler::handle_form()` keeps its working buffers (`$valid_form_data`, `$response_array`) in **static** properties but never resets them at the top of the method. Everything downstream (`validate_form()`, `validate_form_data()`, the repeater-field filter) trusts that buffer to already be an array. On any host that reuses the PHP process across requests (persistent workers), or any path where `handle_form()` runs more than once per process, stale state can leak in and reach `reorganize_form_data()` as `null`. On PHP 8+ that's a hard `TypeError` on `array_key_exists()`, not just a warning like on PHP 7 — so the submission fails outright with "Something went wrong while submitting the form," even for a free/no-payment plan, since the crash happens before any payment gateway code runs.

Fix:
- Reset `self::$response_array` / `self::$valid_form_data` to `array()` at the start of `handle_form()` so no request can inherit stale state from a previous one.
- Guard `reorganize_form_data()` so a non-array `$valid_form_data` can no longer reach `array_key_exists()` and fatal, regardless of upstream cause.

Mirrors the same fix already applied on the Pro side.

Closes UR-4810.

### How to test the changes in this Pull Request:

1. Create a registration form with a Subscription Plan / membership field plus the usual email + password fields.
2. Submit the form (any plan, including Free) and confirm it completes normally with no fatal in `debug.log`.
3. Confirm `array_key_exists()` in `includes/validation/class-ur-form-validation.php` is never reached with a non-array value — `reorganize_form_data()` now normalizes it to `array()` if it isn't one.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Fix: Fatal error on registration submission caused by form validation data becoming null instead of an array, which could break subscription/membership form submissions.