### PR TITLE
UR-4811 Fix - User login after invalid failed payment.

### DIFF
--- a/includes/class-ur-user-approval.php
+++ b/includes/class-ur-user-approval.php
@@ -315,8 +315,9 @@ class UR_User_Approval {
 				$last_order               = $members_order_repository->get_member_orders( $user->ID );
 			}
 
-			$payment_status = get_user_meta( $user->ID, 'ur_payment_status', true );
-			$is_member      = $is_membership_active && ! empty( $membership ) && ! empty( $last_order );
+			$payment_status   = get_user_meta( $user->ID, 'ur_payment_status', true );
+			$requires_payment = 'yes' === get_user_meta( $user->ID, 'ur_requires_payment', true );
+			$is_member        = $is_membership_active && ! empty( $membership ) && ! empty( $last_order );
 			if ( $is_member ) {
 				$payment_status            = $last_order['status'];
 				$membership_payment_method = $last_order['payment_method'];
@@ -331,7 +332,7 @@ class UR_User_Approval {
 			 */
 			do_action( 'ur_user_before_check_payment_status_on_login', $payment_status, $user );
 
-			if ( ! empty( $payment_status ) && 'completed' !== $payment_status ) {
+			if ( 'completed' !== $payment_status && ( $requires_payment || ! empty( $payment_status ) ) ) {
 				$message = '<strong>' . __( 'ERROR:', 'user-registration' ) . '</strong> ' . __( 'Your account is still pending payment.', 'user-registration' );
 
 				$payment_method = $is_member ? $membership_payment_method : get_user_meta( $user->ID, 'ur_payment_method', true );

--- a/includes/frontend/class-ur-frontend-form-handler.php
+++ b/includes/frontend/class-ur-frontend-form-handler.php
@@ -506,6 +506,19 @@ class UR_Frontend_Form_Handler {
 		$login_option = ur_get_user_login_option( $user_id );
 		update_user_meta( $user_id, 'ur_login_option', $login_option );
 
+		// Server-side payment-gate flag so login fails closed even if the client omits membership signals. UR-4811.
+		if ( 'payment' === $login_option && function_exists( 'ur_check_module_activation' ) && ur_check_module_activation( 'membership' ) ) {
+			$hidden_fields = isset( $_POST['urcl_hide_fields'] ) ? (array) json_decode( wp_unslash( $_POST['urcl_hide_fields'] ), true ) : array();
+			foreach ( $valid_form_data as $field ) {
+				if ( isset( $field->extra_params['field_key'] ) && 'membership' === $field->extra_params['field_key'] ) {
+					if ( ! in_array( $field->field_name, $hidden_fields, true ) ) {
+						update_user_meta( $user_id, 'ur_requires_payment', 'yes' );
+					}
+					break;
+				}
+			}
+		}
+
 		$current_language = ur_get_current_language();
 		$current_language = isset( $_POST['registration_language'] ) ? ur_clean( $_POST['registration_language'] ) : $current_language; //phpcs:ignore.
 		update_user_meta( $user_id, 'ur_registered_language', $current_language );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Enforce Payment Before Login server-side: record a `ur_requires_payment` flag at registration for payment-gated membership forms and block login unless payment is completed, so omitting the client-side membership signals (`members_data`/`is_membership_active`/`membership_type`) no longer bypasses the gate.

Closes # .

### How to test the changes in this Pull Request:

Bypass can't be triggered by normal clicking — the 3 signals are always auto-added by the form JS. So: legit paths test purely in UI; the attack needs the request tampered (DevTools). Steps below.

## Setup (one time, UI)
1. Free UR site: http://membership.me
2. Membership > Settings: enable **Bank** gateway.
3. Create membership: **$25 one-time**, role **Subscriber**.
4. Create membership form with fields: Username, Email, Password, Confirm Password, **Membership**. User Login Option = **Payment Before Login**. Publish on a page.
5. Restricted page: Content Restriction block/`urcr_restrict` for Subscriber role. Put text `PAID_MARKER` inside.

## Test A — legit paid still blocked (UI only)
1. Open the registration page, fill fields, pick the $25 plan, choose Bank, submit.
2. Try to log in as that user.
3. Expect: **"Your account is still pending payment."** No login. (Unchanged by fix.)

## Test B — legit free still works (UI only)
1. Make a second membership: **Free**, role Subscriber. Add to form (or a second form, payment login).
2. Register, pick free plan, submit. Log in.
3. Expect: login succeeds. (Fix must not break this.)

## Test C — the bypass (needs DevTools)
1. Chrome DevTools > Network tab open. Register normally once on the paid form.
2. Find the `admin-ajax.php` request with `action=user_registration_user_form_submit`. Right-click > **Copy > Copy as fetch**.
3. Paste into DevTools Console. Delete these 3 keys from the body: `members_data`, `is_membership_active`, `membership_type`. Change username/email to a fresh value. Run it.
4. Try to log in as that new user.

**Before fix:** login succeeded, `PAID_MARKER` visible = bypass.
**After fix (now):** login blocked with "still pending payment." Bypass closed.

## Verify server state (confirms the flag)
Run after Test C registration:
```bash
cd /c/laragon/www/membership && "/c/laragon/bin/mysql/mysql-8.4.3-winx64/bin/mysql.exe" -uroot membership -e "SELECT u.user_login, m1.meta_value AS login_option, m2.meta_value AS requires_payment, m3.meta_value AS payment_status FROM wp_users u LEFT JOIN wp_usermeta m1 ON m1.user_id=u.ID AND m1.meta_key='ur_login_option' LEFT JOIN wp_usermeta m2 ON m2.user_id=u.ID AND m2.meta_key='ur_requires_payment' LEFT JOIN wp_usermeta m3 ON m3.user_id=u.ID AND m3.meta_key='ur_payment_status' ORDER BY u.ID DESC LIMIT 5;"
```
Expect bypass account: `login_option=payment`, `requires_payment=yes`, `payment_status=` empty → gate blocks.


### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - User login after invalid failed payment.
