### PR TITLE
UR-4798 Fix - Fall back to basic profile fields for non-UR-form users

### DIFF
--- a/includes/class-ur-ajax.php
+++ b/includes/class-ur-ajax.php
@@ -275,6 +275,11 @@ class UR_AJAX {
 
 		$profile = user_registration_form_data( $user_id, $form_id );
 
+		// No resolvable UR form (e.g. wp-admin/WooCommerce created user) - fall back to basic fields.
+		if ( empty( $profile ) ) {
+			$profile = ur_get_non_urm_user_profile_fields( $user_id );
+		}
+
 		if ( empty( $profile ) ) {
 			wp_send_json_error(
 				array(

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -11134,6 +11134,51 @@ if ( ! function_exists( 'urm_process_profile_fields' ) ) {
 	}
 }
 
+if ( ! function_exists( 'ur_get_non_urm_user_profile_fields' ) ) {
+	/**
+	 * Fallback profile fields for users with no resolvable UR registration form.
+	 *
+	 * @param int $user_id User ID.
+	 *
+	 * @return array
+	 */
+	function ur_get_non_urm_user_profile_fields( $user_id ) {
+		if ( ! get_userdata( $user_id ) ) {
+			return array();
+		}
+
+		return apply_filters(
+			'user_registration_non_urm_user_profile_fields',
+			array(
+				'user_registration_user_login' => array(
+					'label'     => __( 'Username', 'user-registration' ),
+					'type'      => 'text',
+					'field_key' => 'user_login',
+					'required'  => true,
+				),
+				'user_registration_first_name' => array(
+					'label'     => __( 'First Name', 'user-registration' ),
+					'type'      => 'text',
+					'field_key' => 'first_name',
+					'required'  => false,
+				),
+				'user_registration_user_email' => array(
+					'label'     => __( 'User Email', 'user-registration' ),
+					'type'      => 'email',
+					'field_key' => 'user_email',
+					'required'  => true,
+				),
+				'user_registration_last_name'  => array(
+					'label'     => __( 'Last Name', 'user-registration' ),
+					'type'      => 'text',
+					'field_key' => 'last_name',
+					'required'  => false,
+				),
+			),
+			$user_id
+		);
+	}
+}
 
 if ( ! function_exists( 'urm_update_user_profile_data' ) ) {
 	/**

--- a/templates/myaccount/form-edit-profile-non-urm-user.php
+++ b/templates/myaccount/form-edit-profile-non-urm-user.php
@@ -171,7 +171,40 @@ $endpoint_label = isset( $args['endpoint_label'] ) ? $args['endpoint_label'] : '
 										</div>
 										<div class="ur-form-grid ur-grid-2" style="width:48%;">
 											<div class="ur-field-item field-user_email" data-field-id="user_email" data-ref-id="user_registration_user_email">
-												<div class="form-row validate-required" id="user_registration_user_email_field" data-priority=""><label for="user_registration_user_email" class="ur-label"><?php _e( 'User Email', 'user-registration' ); ?> <abbr class="required" title="required">*</abbr></label> <span class="input-wrapper"> <input data-rules="" data-id="user_registration_user_email" type="email" class="input-text  without_icon input-email ur-edit-profile-field " name="user_registration_user_email" id="user_registration_user_email" placeholder="" value="<?php echo $user->user_email; ?>" required="required" data-default="zapoda@mailinator.com"> </span> </div>
+												<?php
+												// Same pending-email notice non-ajax UR-form fields get (see functions-ur-template.php).
+												// Rendered right after the input - matches where the ajax success handler
+												// looks (input.next('div.email-updated')) so it gets replaced, not duplicated.
+												$pending_email       = get_user_meta( $user_id, 'user_registration_pending_email', true );
+												$expiration          = get_user_meta( $user_id, 'user_registration_pending_email_expiration', true );
+												$pending_email_notice = '';
+
+												if ( ! empty( $pending_email ) && time() <= $expiration ) {
+													$cancel_url = esc_url(
+														add_query_arg(
+															array(
+																'cancel_email_change' => $user_id,
+																'_wpnonce'            => wp_create_nonce( 'cancel_email_change_nonce' ),
+															),
+															ur_get_my_account_url() . get_option( 'user_registration_myaccount_edit_profile_endpoint', 'edit-profile' )
+														)
+													);
+													$pending_email_notice = sprintf(
+														'<div class="email-updated inline"><p>%s</p></div>',
+														wp_kses_post(
+															sprintf(
+																/* translators: 1: Pending email 2: Cancel link */
+																__( 'There is a pending change of your email to <code>%1$s</code>. <a href="%2$s">Cancel</a>', 'user-registration' ),
+																esc_html( $pending_email ),
+																$cancel_url
+															)
+														)
+													);
+												} else {
+													UR_Form_Handler::delete_pending_email_change( $user_id );
+												}
+												?>
+												<div class="form-row validate-required" id="user_registration_user_email_field" data-priority=""><label for="user_registration_user_email" class="ur-label"><?php _e( 'User Email', 'user-registration' ); ?> <abbr class="required" title="required">*</abbr></label> <span class="input-wrapper"> <input data-rules="" data-id="user_registration_user_email" type="email" class="input-text  without_icon input-email ur-edit-profile-field " name="user_registration_user_email" id="user_registration_user_email" placeholder="" value="<?php echo $user->user_email; ?>" required="required" data-default="zapoda@mailinator.com"> <?php echo $pending_email_notice; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already wp_kses_post()'d above. ?></span> </div>
 											</div>
 											<div class="ur-field-item field-last_name" data-field-id="last_name" data-ref-id="user_registration_last_name">
 												<div class="form-row" id="user_registration_last_name_field" data-priority=""><label for="user_registration_last_name" class="ur-label"><?php _e( 'Last Name', 'user-registration' ); ?></label> <span class="input-wrapper"> <input data-rules="" data-id="user_registration_last_name" type="text" class="input-text  without_icon input-text ur-edit-profile-field " name="user_registration_last_name" id="user_registration_last_name" placeholder="" value="<?php echo esc_attr( $user->last_name ); ?>" data-default=""> </span> </div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

https://themegrill.atlassian.net/browse/UR-4798

Follow-up to #1384. That PR fixed the false success message, but users with no resolvable `ur_form_id` (created via wp-admin or WooCommerce, not a UR form) still couldn't actually save Profile Details - `user_registration_form_data()` returns an empty profile for them, so the save loop has nothing to write.

Two parts:

1. **Make the save actually work.** Added `ur_get_non_urm_user_profile_fields()` (basic Username/First Name/Email/Last Name fields, matching `templates/myaccount/form-edit-profile-non-urm-user.php`) and used it as a fallback in `update_profile_details()` when the profile comes back empty, so these users can now genuinely save their basic details.
2. **Pending-email notice for the non-UR-form template.** UR-form fields already show a "There is a pending change of your email to ... Cancel" notice (`functions-ur-template.php`) after an email change, but the non-UR-form template never rendered it - it only appeared via the AJAX success handler's client-side insert, so a non-ajax submit or a fresh page load showed nothing. Added the same server-rendered notice to `form-edit-profile-non-urm-user.php`, placed as the direct next sibling of the `<input>` (matching where the AJAX success handler looks for `input.next('div.email-updated')`) so an AJAX save correctly replaces it instead of leaving a stale duplicate.

`user_registration_form_data()` itself is left untouched - it's shared by ~15 other call sites (CSV export, admin user list, emailer, membership AJAX), so this is scoped to just the save handler and its template.

Closes # .

### How to test the changes in this Pull Request:

1. Create a user with no resolvable `ur_form_id` (wp-admin Add New, or WooCommerce checkout).
2. Log in as that user, go to My Account → Profile Details.
3. Update First Name / Last Name / Email and save (with "Ajax Submission on Edit Profile" both on and off) - reload and confirm the values actually persisted.
4. Change the email again and confirm the pending-email notice with a working Cancel link shows in both the ajax and non-ajax case, with no duplicate notices.
5. Confirm a normal user with a valid UR form still saves as before (no regression).

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Fix - Users without a resolvable registration form can now update their profile details from My Account.
