### PR TITLE
UR-4815 - Support Member Search by Full Name

### DIFF
--- a/includes/admin/settings/class-ur-members-list-table.php
+++ b/includes/admin/settings/class-ur-members-list-table.php
@@ -1494,6 +1494,26 @@ if ( ! class_exists( 'User_Registration_Members_ListTable' ) ) {
 					$search_like
 				);
 
+				// Also match the full name (e.g. "John Smith") when first/last name are stored
+				// as separate usermeta rather than combined into a single field like display_name.
+				$search_conditions[] = $wpdb->prepare(
+					"EXISTS (
+						SELECT 1
+						FROM {$wpdb->usermeta} umfn
+						JOIN {$wpdb->usermeta} umln
+							ON umln.user_id = umfn.user_id
+							AND umln.meta_key = 'last_name'
+						WHERE umfn.user_id = {$wpdb->users}.ID
+						AND umfn.meta_key = 'first_name'
+						AND (
+							CONCAT( umfn.meta_value, ' ', umln.meta_value ) LIKE %s
+							OR CONCAT( umln.meta_value, ' ', umfn.meta_value ) LIKE %s
+						)
+					)",
+					$search_like,
+					$search_like
+				);
+
 				$search_conditions[] = $wpdb->prepare(
 					"EXISTS (
 						SELECT 1


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Member search (User Registration → Members) already matched `first_name`, `last_name`, and `nickname` usermeta individually, but never checked them combined. So searching a full name (e.g. "John Smith") returned no results whenever the name was stored as separate first/last usermeta rather than combined into a single field like `display_name`.

Adds a concatenated `first_name + ' ' + last_name` match (both orders) alongside the existing per-field checks in `urm_search_user_on_name()`, so:

- Full name search ("John Smith") now matches when first/last are stored separately.
- Full name search still matches when the name lives in a single field (e.g. `display_name`) — unchanged.
- Searching an individual part ("John" or "Smith" alone) still matches — unchanged.
- Purely additive OR condition; no existing behavior removed.

Closes UR-4815.

### How to test the changes in this Pull Request:

1. Go to **User Registration → Members** and edit/add a user whose `display_name` does **not** already equal their full name (e.g. set "Display name publicly as" to the username), but who has First Name / Last Name set on their profile.
2. Search for the user's full name, e.g. `John Smith` — before this fix, no results; after, the user is found.
3. Confirm searching just `John` or just `Smith` still finds the user.
4. Confirm searching by email, username, or an already-matching `display_name` still works as before.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Fix: Member search now matches full name even when First Name and Last Name are stored as separate fields.
