### PR TITLE
UR-4830: Fix Membership Renewal Reminder sent for subscriptions cancelled at period end

### DIFF
--- a/modules/membership/includes/Admin/Services/SubscriptionService.php
+++ b/modules/membership/includes/Admin/Services/SubscriptionService.php
@@ -270,7 +270,13 @@ class SubscriptionService {
 		}
 		$email_service = new EmailService();
 		foreach ( $subscriptions as $subscription ) {
-			$user_id      = $subscription['member_id'];
+			$user_id = $subscription['member_id'];
+
+			// Skip memberships already scheduled to cancel; they will not renew, so no renewal reminder.
+			if ( get_user_meta( $user_id, 'urm_pending_cancel_' . ( $subscription['subscription_id'] ?? '' ), true ) ) {
+				continue;
+			}
+
 			$checked_date = get_user_meta( $user_id, 'urm_billing_reminder_sent_for_date', true );
 			if ( $checked_date === $subscription['next_billing_date'] ) {
 				continue;


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

A member who cancels a subscription **at period end** still receives the **Membership Renewal Reminder** email, telling them they are about to be billed for a membership they already cancelled.

**Cause**

When a subscription is cancelled while the paid period is still running, we intentionally keep it `active` until the end date and record the cancellation in user meta instead:

```php
// SubscriptionRepository::cancel_subscription_by_id()
if ( ! empty( $expiry_date ) && strtotime( $expiry_date ) > time() ) {
	update_user_meta( $subscription['user_id'], 'urm_pending_cancel_' . $subscription_id, $expiry_date );
} else {
	$this->update( $subscription_id, array( 'status' => 'canceled' ) );
}
```

`daily_membership_renewal_check()` then picks it up, because `get_about_to_expire_subscriptions()` filters on status and billing date only:

```sql
WHERE NOT wums.status = 'canceled'
AND DATE(wums.next_billing_date) = DATE('%s')
```

Nothing in the loop consults the `urm_pending_cancel_<subscription_id>` meta, so a cancelled-at-period-end membership matches and the reminder goes out.

**Fix**

Skip subscriptions that already carry the pending-cancel meta. This is the same guard `daily_membership_expiring_soon_check()` already has — it was applied there and missed here. Which of the two crons runs depends on `user_registration_renewal_behaviour` (`automatic` → renewal reminder, `manual` → expiring soon), so sites on automatic renewal hit the unguarded path.

Notification-only defect: no payment is taken and the subscription record is unaffected. Reported by a customer whose member cancelled on Stripe with `cancel_at_period_end`, then received the reminder on the period end date itself.

Closes # .

### How to test the changes in this Pull Request:

1. Enable membership with a recurring paid plan, and set **Renewal Behaviour** to `Automatic` with the Renewal Reminder email enabled.
2. Register a member on the plan so a subscription with a future `next_billing_date` / `expiry_date` exists.
3. Cancel the membership from **My Account → Membership** while the paid period is still running. Confirm the subscription stays `active` and `urm_pending_cancel_<subscription_id>` user meta is set (the admin list shows "Cancels \<date\>").
4. Set the reminder window so the subscription falls inside it — e.g. `user_registration_membership_renewal_reminder_days_before` / `_period` such that today + window equals `next_billing_date`.
5. Run `urm_daily_membership_renewal_check` (WP Crontrol, or `wp cron event run urm_daily_membership_renewal_check`).
6. **Before:** the member receives the Membership Renewal Reminder. **After:** no email is sent.
7. Regression check: repeat with a normal active subscription that was never cancelled — the reminder must still be sent as before.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Fix - Membership Renewal Reminder email sent to members who had already cancelled at period end.
