### PR TITLE
UR-4833: Fix selected membership not assigned, payment not processed and auto login not working

### DIFF
--- a/includes/frontend/class-ur-frontend-form-handler.php
+++ b/includes/frontend/class-ur-frontend-form-handler.php
@@ -99,7 +99,7 @@ class UR_Frontend_Form_Handler {
 		 *
 		 * @return array
 		 */
-		apply_filters_ref_array(
+		do_action_ref_array(
 			'user_registration_validate_form_data',
 			array(
 				&self::$valid_form_data,

--- a/includes/frontend/class-ur-frontend-form-handler.php
+++ b/includes/frontend/class-ur-frontend-form-handler.php
@@ -93,13 +93,22 @@ class UR_Frontend_Form_Handler {
 		$user_pass = '';
 
 		/**
-		 * Get form field data by post_content array passed.
+		 * Filters the valid form data before the frontend handler proceeds.
 		 *
-		 * @param array $post_content_array Post Content Array.
+		 * Every callback (built-in or third-party) must return $valid_form_data,
+		 * possibly augmented, since WordPress feeds each callback's return value
+		 * into the next as the reference argument; returning nothing wipes it.
+		 *
+		 * @param array  $valid_form_data Valid form data, passed and returned by reference.
+		 * @param array  $form_field_data Form field data.
+		 * @param array  $form_data       Submitted form data.
+		 * @param int    $form_id         Form ID.
+		 * @param array  $response_array  Response array, passed by reference.
+		 * @param string $user_pass       Auto-generated user password, passed by reference.
 		 *
 		 * @return array
 		 */
-		do_action_ref_array(
+		apply_filters_ref_array(
 			'user_registration_validate_form_data',
 			array(
 				&self::$valid_form_data,

--- a/includes/validation/class-ur-form-validation.php
+++ b/includes/validation/class-ur-form-validation.php
@@ -117,7 +117,7 @@ class UR_Form_Validation extends UR_Validation {
 	 * @param [int]    $form_id Form Id.
 	 * @param [array]  $response_array UR_Frontend_Form_Handler::$response_array reference.
 	 * @param [string] $user_pass User Password reference.
-	 * @return void
+	 * @return array Valid form data, returned so a later callback on the same filter doesn't wipe it.
 	 */
 	public function validate_form( &$valid_form_data, $form_field_data, $form_data, $form_id, &$response_array, &$user_pass ) {
 		$this->valid_form_data = $valid_form_data;
@@ -157,6 +157,8 @@ class UR_Form_Validation extends UR_Validation {
 
 		// Modify UR_Frontend_Form_Handler::$valid_form_data variable.
 		$valid_form_data = $this->valid_form_data;
+
+		return $valid_form_data;
 	}
 
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

**Updated approach (see review discussion below):** the original commit changed the `user_registration_validate_form_data` dispatch from `apply_filters_ref_array()` to `do_action_ref_array()`. Copilot correctly flagged that as a breaking API change — it silently discards any third-party filter callback's return value, at every position in the chain, not just the last one. That's now reverted.

**Actual root cause:** `UR_Form_Validation::validate_form()`, the plugin's own callback on this hook, mutates `$valid_form_data` by reference but never returns it. `WP_Hook::apply_filters()` feeds each callback's return value into the next callback's copy of the by-reference argument. Because the built-in callback returns nothing, the very next callback in the chain — any third-party plugin also hooked here — receives `null` instead of the validated data.

| Lost field | Symptom |
|---|---|
| `user_login` | `wp_insert_user()` fails with `empty_user_login` → **"Cannot create a user with an empty login name."** Registration fails, so auto login never happens. |
| membership field | `process_membership_after_registration()` finds no field with `field_key === 'membership'` and hits a silent `return`, leaving an account with **no plan, no order, no subscription**. |
| `payment_method` / plan | No payable order is produced, so **payment is never processed**. |

**Fix:**
- Kept `apply_filters_ref_array()` as-is (no change to the public hook's dispatch/contract).
- Added the missing `return $valid_form_data;` to `UR_Form_Validation::validate_form()`.
- Corrected the stale docblocks on both (the hook docblock still described an unrelated `$post_content_array` param; `validate_form()`'s docblock said `@return void`).

Verified against WordPress's own `wp-includes/class-wp-hook.php` (not just manual reasoning): before the fix `$valid_form_data` ends up `NULL` when a second callback is attached, matching the report; after the fix it's intact, and a third-party filter that augments the array via return (the documented filter pattern) is now honoured too, which it would not have been under `do_action_ref_array`.

Any third-party plugin (or another addon) that hooks `user_registration_validate_form_data` triggers this, which is why it reproduces on some sites and not others.

Closes # .

### How to test the changes in this Pull Request:

1. Create a registration form containing a **Username** field and a **Membership** field with at least one free plan, and put it on a page.
2. Add a mu-plugin with a deliberately harmless no-op filter — it does nothing but return its input:
   ```php
   add_filter( 'user_registration_validate_form_data', function ( $valid_form_data ) {
       return $valid_form_data;
   }, 20, 1 );
   ```
3. **Before this patch:** submit the form → registration fails with *"Cannot create a user with an empty login name."* If the site works around the empty login (e.g. a `pre_user_login` filter), the user is created but gets no membership, no order and no subscription, while the form still reports success.
4. **After this patch:** submit the form → registration succeeds, the username is stored exactly as typed, and the member gets the selected plan with an order and an active subscription.
5. Remove the mu-plugin and register again to confirm the default single-callback path is unchanged.
6. To confirm the filter contract itself is unbroken: replace the mu-plugin above with one that augments and returns a modified copy (e.g. `$valid_form_data['custom'] = 'x'; return $valid_form_data;`) and confirm `custom` is still present in the validated data — this would silently fail under the previous `do_action_ref_array` approach.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

Verified on a customer site running Pro 6.2.7 where a third-party plugin hooks this filter: before the change new users were created with no membership (and usernames silently derived from their e-mail by the site's own workaround); after the change registration stores the username as typed, assigns the plan, creates the order and the subscription, and the member area shows the correct tier and quota.

### Changelog entry

Fix - Selected membership not assigned, payment not processed and auto login not working when another plugin hooks `user_registration_validate_form_data`.
