### PR TITLE
UR-4807 Fix - Payments table product column empty when invoice_plan is not set

### DIFF
--- a/modules/payment-history/Admin/OrdersListTable.php
+++ b/modules/payment-history/Admin/OrdersListTable.php
@@ -186,7 +186,7 @@ class OrdersListTable extends \UR_List_Table {
 					'display_name'   => $user->user_login,
 					'user_email'     => $user->user_email,
 					'transaction_id' => $meta_value[0]['invoice_no'] ?? '',
-					'post_title'     => $meta_value[0]['invoice_plan'] ?? '',
+					'post_title'     => $this->get_invoice_product_label( $meta_value[0] ?? array() ),
 					'status'         => get_user_meta( $user->ID, 'ur_payment_status', true ),
 					'created_at'     => $meta_value[0]['invoice_date'] ?? '',
 					'type'           => get_user_meta( $user->ID, 'ur_payment_type', true ),
@@ -243,6 +243,53 @@ class OrdersListTable extends \UR_List_Table {
 	 *
 	 * @return array
 	 */
+
+	/**
+	 * Product name for a payment record.
+	 *
+	 * Only Stripe subscriptions set invoice_plan; PayPal, Mollie and one-time
+	 * payments do not, so fall back to the labels stored in the cart items.
+	 *
+	 * @param array $invoice First entry of ur_payment_invoices.
+	 * @return string
+	 */
+	private function get_invoice_product_label( $invoice ) {
+		if ( ! empty( $invoice['invoice_plan'] ) ) {
+			return $invoice['invoice_plan'];
+		}
+
+		$items = isset( $invoice['invoice_item'] ) ? $invoice['invoice_item'] : '';
+
+		// ur_cart_items is read without the single flag, so it arrives wrapped in an array.
+		if ( is_array( $items ) ) {
+			$items = reset( $items );
+		}
+
+		if ( is_string( $items ) ) {
+			$items = json_decode( $items );
+		}
+
+		if ( empty( $items ) || ! is_array( $items ) ) {
+			return '';
+		}
+
+		$labels = array();
+
+		foreach ( $items as $item ) {
+			// Choice based fields store the selection as label => amount.
+			if ( isset( $item->value ) && ( is_array( $item->value ) || is_object( $item->value ) ) ) {
+				$labels = array_merge( $labels, array_keys( (array) $item->value ) );
+				continue;
+			}
+
+			if ( ! empty( $item->label ) ) {
+				$labels[] = $item->label;
+			}
+		}
+
+		return implode( ', ', array_unique( array_filter( $labels ) ) );
+	}
+
 	public function get_columns() {
 		return array(
 			'cb'              => '<input type="checkbox" />',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Jira: [UR-4807](https://themegrill.atlassian.net/browse/UR-4807)

The payments table Product column read `invoice_plan` from `ur_payment_invoices`, which only Stripe subscriptions ever set. It was blank for Authorize.net, PayPal, Mollie and one-time payments.

Falls back to the labels stored in the cart items when `invoice_plan` is absent, so existing records are fixed too with no data migration. `invoice_plan` still wins when present, so Stripe is unchanged.

Keeps `OrdersListTable.php` in sync with wpeverest/user-registration-pro#1395.

### How to test the changes in this Pull Request:

1. Go to Payments (Payment History).
2. Product column shows a value for Authorize.net, PayPal and Mollie records instead of being empty.
3. Stripe subscription records are unchanged.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

Fix - Payments table Product column was empty for Authorize.net, PayPal and Mollie payments.


[UR-4807]: https://themegrill.atlassian.net/browse/UR-4807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ