### PR TITLE
UR-4768 UR-4857 UR-4855 UR-4767 Sync - Membership payment retry from pro

### DIFF
--- a/modules/membership/includes/Admin/Repositories/MembersSubscriptionRepository.php
+++ b/modules/membership/includes/Admin/Repositories/MembersSubscriptionRepository.php
@@ -289,6 +289,11 @@ class MembersSubscriptionRepository extends BaseRepository implements MembersSub
 
 	/**
 	 * Fetches the list of subscriptions to retry based on payment retry settings and billing expiry.
+	 *
+	 * The orders join is pinned to each subscription's most recent order. Joining
+	 * every order returned one row per order, so a subscription with N orders was
+	 * retried N times in a single run - N counter increments, N failed order rows
+	 * and N duplicate emails to the member. See UR-4855.
 	 */
 	public function get_subscriptions_to_retry() {
 		// Check if payment retry is enabled
@@ -325,7 +330,9 @@ class MembersSubscriptionRepository extends BaseRepository implements MembersSub
 			FROM $this->table wums
 			LEFT JOIN $this->users_table wu ON wums.user_id = wu.ID
 			LEFT JOIN $this->posts_table wp ON wums.item_id = wp.ID
-			LEFT JOIN $this->orders_table wo ON wums.ID = wo.subscription_id
+			LEFT JOIN $this->orders_table wo ON wo.ID = (
+				SELECT MAX( o2.ID ) FROM $this->orders_table o2 WHERE o2.subscription_id = wums.ID
+			)
 			WHERE (wums.status = 'failed' OR wums.status = 'expired')
 			AND wums.updated_at >= '%s'
 			ORDER BY wums.updated_at ASC

--- a/modules/membership/includes/Admin/Services/EmailService.php
+++ b/modules/membership/includes/Admin/Services/EmailService.php
@@ -314,6 +314,11 @@ class EmailService {
 			return;
 		}
 
+		// Respect the per-email toggle; defaults to on so existing installs are unaffected.
+		if ( ! ur_option_checked( 'user_registration_enable_payment_retry_failed_email', true ) ) {
+			return;
+		}
+
 		$subject  = __( 'Payment Attempt Failed – Action Required on {{blog_info}}', 'user-registration' );
 		$subject  = get_option( 'user_registration_payment_retry_failed_email_subject', $subject );
 		$settings = $email_classes['UR_Settings_Payment_Retry_Failed_Email'];
@@ -348,6 +353,11 @@ class EmailService {
 		$email_classes = apply_filters( 'user_registration_email_classes', array() );
 
 		if ( ! isset( $email_classes['UR_Settings_Payment_Retry_Cancel_Email'] ) ) {
+			return;
+		}
+
+		// Respect the per-email toggle; defaults to on so existing installs are unaffected.
+		if ( ! ur_option_checked( 'user_registration_enable_payment_retry_cancel_email', true ) ) {
 			return;
 		}
 

--- a/modules/membership/includes/Admin/Services/EmailService.php
+++ b/modules/membership/includes/Admin/Services/EmailService.php
@@ -315,6 +315,7 @@ class EmailService {
 		}
 
 		$subject  = __( 'Payment Attempt Failed – Action Required on {{blog_info}}', 'user-registration' );
+		$subject  = get_option( 'user_registration_payment_retry_failed_email_subject', $subject );
 		$settings = $email_classes['UR_Settings_Payment_Retry_Failed_Email'];
 		$message  = $settings->ur_get_payment_retry_failed_email();
 		$message  = get_option( 'user_registration_payment_retry_failed_email', $message );
@@ -351,6 +352,7 @@ class EmailService {
 		}
 
 		$subject  = __( 'Payment Cancelled – Registration Cancelled on {{blog_info}}', 'user-registration' );
+		$subject  = get_option( 'user_registration_payment_retry_cancel_email_subject', $subject );
 		$settings = $email_classes['UR_Settings_Payment_Retry_Cancel_Email'];
 		$message  = $settings->ur_get_payment_retry_cancel_email();
 		$message  = get_option( 'user_registration_payment_retry_cancel_email', $message );

--- a/modules/membership/includes/Admin/Services/Stripe/StripeService.php
+++ b/modules/membership/includes/Admin/Services/Stripe/StripeService.php
@@ -2986,26 +2986,13 @@ class StripeService {
 						)
 					);
 
-					// Notify user via email about a failed retry attempt.
-					$current_subscription = $this->members_subscription_repository->get_membership_by_subscription_id( $subscription['sub_id'], true );
-					if ( ! empty( $current_subscription ) ) {
-						$member_id = $current_subscription['user_id'];
-
-						if ( 1 === (int) get_user_meta( $member_id, 'urm_is_payment_retrying', true ) ) {
-							$latest_order     = $this->members_orders_repository->get_member_orders( $member_id );
-							$membership       = $this->membership_repository->get_single_membership_by_ID( $current_subscription['item_id'] );
-							$membership_metas = wp_unslash( json_decode( $membership['meta_value'], true ) );
-							$email_service    = new EmailService();
-							$email_data       = array(
-								'subscription'     => $current_subscription,
-								'order'            => $latest_order,
-								'membership_metas' => $membership_metas,
-								'member_id'        => $member_id,
-							);
-							$email_service->send_email( $email_data, 'payment_retry_failed' );
-						}
-						$response['message'] = __( 'Subscription retry did not resolve the issue', 'user-registration' );
-					}
+					/*
+					 * The member notification and the failed order row are handled
+					 * centrally by SubscriptionService::record_failed_retry_attempt()
+					 * off this method's return value, so every failure path notifies
+					 * once and only once. See UR-4857.
+					 */
+					$response['message'] = __( 'Subscription retry did not resolve the issue', 'user-registration' );
 				}
 			} elseif ( 'active' === $stripe_subscription->status || 'trialing' === $stripe_subscription->status ) {
 				// Scenario: if automatic retry is enabled in stripe dashboard, it might be already active via smart retry.

--- a/modules/membership/includes/Admin/Services/SubscriptionService.php
+++ b/modules/membership/includes/Admin/Services/SubscriptionService.php
@@ -1422,6 +1422,13 @@ class SubscriptionService {
 		 */
 		if ( is_array( $result ) && empty( $result['status'] ) ) {
 			$this->record_failed_retry_attempt( $subscription, isset( $result['message'] ) ? $result['message'] : '' );
+		} elseif ( is_array( $result ) ) {
+			/*
+			 * Payment recovered, so the retry run is over. Without this the counter
+			 * keeps its old value, and the member's next failure starts at or past
+			 * user_registration_payment_retry_count with no retry grace left.
+			 */
+			delete_user_meta( $subscription['member_id'], 'urm_is_payment_retrying' );
 		}
 	}
 

--- a/modules/membership/includes/Admin/Services/SubscriptionService.php
+++ b/modules/membership/includes/Admin/Services/SubscriptionService.php
@@ -1379,22 +1379,113 @@ class SubscriptionService {
 	 * Payment retry callback for a failed attempt.
 	 */
 	public function failed_payment_retry_callback( $subscription ) {
+		/**
+		 * Allow a gateway that retries failed payments on its own side to opt out
+		 * of the scheduler-driven retry.
+		 *
+		 * Authorize.Net (ARB) re-attempts collection itself and reports the outcome
+		 * over webhooks, so running it through here would double-count the retry
+		 * attempt against `urm_is_payment_retrying`.
+		 *
+		 * @param bool  $should_retry Whether the scheduler should drive this retry.
+		 * @param array $subscription Subscription row from get_subscriptions_to_retry().
+		 */
+		if ( ! apply_filters( 'urm_should_handle_failed_payment_retry', true, $subscription ) ) {
+			return;
+		}
+
 		// update the counter for failed payment retry.
 		$retry_count = (int) get_user_meta( $subscription['member_id'], 'urm_is_payment_retrying', true );
 		update_user_meta( $subscription['member_id'], 'urm_is_payment_retrying', $retry_count + 1 );
+		$result = null;
+
 		switch ( $subscription['payment_method'] ) {
 			case 'paypal':
 				$paypal_service = new NewPaypalService();
-				$paypal_service->retry_subscription( $subscription );
+				$result         = $paypal_service->retry_subscription( $subscription );
 				break;
 			case 'stripe':
 				$stripe_service = new StripeService();
-				$stripe_service->retry_subscription( $subscription );
+				$result         = $stripe_service->retry_subscription( $subscription );
 				break;
 			default:
+				// Gateways on this hook report the outcome themselves.
 				do_action( 'urm_handle_failed_payment_retry', $subscription );
-				break;
+				return;
 		}
+
+		/*
+		 * Stripe and PayPal report the outcome through their return value, which
+		 * used to be discarded — so a failed retry left no order row and sent the
+		 * member no email. Record and notify centrally instead, matching what the
+		 * webhook-driven gateways already do. See UR-4857.
+		 */
+		if ( is_array( $result ) && empty( $result['status'] ) ) {
+			$this->record_failed_retry_attempt( $subscription, isset( $result['message'] ) ? $result['message'] : '' );
+		}
+	}
+
+	/**
+	 * Record a failed retry attempt and tell the member.
+	 *
+	 * @param array  $subscription Subscription row from get_subscriptions_to_retry().
+	 * @param string $reason       Gateway-supplied failure message, for the order note.
+	 *
+	 * @return void
+	 */
+	protected function record_failed_retry_attempt( $subscription, $reason = '' ) {
+		$member_id = isset( $subscription['member_id'] ) ? absint( $subscription['member_id'] ) : 0;
+		$sub_pk    = isset( $subscription['subscription_id'] ) ? absint( $subscription['subscription_id'] ) : 0;
+
+		if ( ! $member_id || ! $sub_pk ) {
+			return;
+		}
+
+		$member_subscription = $this->members_subscription_repository->retrieve( $sub_pk );
+
+		if ( empty( $member_subscription ) ) {
+			return;
+		}
+
+		$membership       = $this->membership_repository->get_single_membership_by_ID( $member_subscription['item_id'] );
+		$membership_metas = empty( $membership['meta_value'] ) ? array() : (array) wp_unslash( json_decode( $membership['meta_value'], true ) );
+
+		$order_info = array(
+			'membership_data' => array(
+				'membership'     => $member_subscription['item_id'],
+				'payment_method' => $subscription['payment_method'],
+			),
+		);
+
+		$order_service = new OrderService();
+		$order_data    = $order_service->prepare_orders_data( $order_info, $member_id, $member_subscription );
+
+		$note = __( 'Renewal payment retry failed', 'user-registration' );
+
+		if ( ! empty( $reason ) ) {
+			$note .= ' - ' . $reason;
+		}
+
+		$order_data['orders_data']['status']          = 'failed';
+		$order_data['orders_data']['user_id']         = $member_id;
+		$order_data['orders_data']['created_by']      = $member_id;
+		$order_data['orders_data']['trial_status']    = 'off';
+		$order_data['orders_data']['notes']           = sanitize_text_field( $note );
+		$order_data['orders_data']['total_amount']    = isset( $membership_metas['amount'] ) ? $membership_metas['amount'] : 0;
+		$order_data['orders_data']['subscription_id'] = $member_subscription['ID'];
+
+		$this->orders_repository->create( $order_data );
+
+		$email_service = new EmailService();
+		$email_service->send_email(
+			array(
+				'subscription'     => $member_subscription,
+				'order'            => $this->members_orders_repository->get_member_orders( $member_id ),
+				'membership_metas' => $membership_metas,
+				'member_id'        => $member_id,
+			),
+			'payment_retry_failed'
+		);
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes UR-4768, UR-4857, UR-4855, UR-4767.

Sync of the membership payment retry changes from wpeverest/user-registration-pro#1396. There are no independent changes here — the four touched files are byte-identical to the Pro tree.

- `modules/membership/includes/Admin/Services/SubscriptionService.php` — `urm_should_handle_failed_payment_retry` filter, `record_failed_retry_attempt()`, and the retry counter reset on success.
- `modules/membership/includes/Admin/Repositories/MembersSubscriptionRepository.php` — the retry query joins only each subscription's latest order, so one subscription is retried once per run.
- `modules/membership/includes/Admin/Services/Stripe/StripeService.php` — inline retry email removed; failures are now reported centrally.
- `modules/membership/includes/Admin/Services/EmailService.php` — retry email subjects read their own options, and the per-email enable toggle is honoured.

### How to test the changes in this Pull Request:

1. Follow the test steps on wpeverest/user-registration-pro#1396 — the behaviour is identical.
2. To confirm the sync itself, diff the two trees:

```
diff -r user-registration/modules/membership/includes/Admin \
        user-registration-pro/modules/membership/includes/Admin
```

The four files listed above should show no differences.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [x] Enhancement (modification of the currently available functionality)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

Parity with Pro was confirmed by diff after each sync commit.

### Changelog entry

Fix - Stripe and PayPal payment retries now record a failed order and notify the member.
Fix - A subscription with multiple orders is no longer retried once per order.
Fix - Payment retry counter is cleared once a payment succeeds.
Fix - Payment retry emails now save to and read from their own settings, and honour their enable toggle.
Enhancement - Gateways that retry on their own side can opt out of the scheduler via `urm_should_handle_failed_payment_retry`.
