### PR TITLE
Add PR build-zip workflow

### DIFF
--- a/.github/workflows/pr-build-zip.yml
+++ b/.github/workflows/pr-build-zip.yml
@@ -1,0 +1,26 @@
+name: Build Testable ZIP
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  zip:
+    uses: wpeverest/.github/.github/workflows/pr-build-zip.yml@master
+    with:
+      node-version: '20.x'
+      php-version: '7.4'
+      package-manager: pnpm
+      # `pnpm exec grunt` needs grunt already in node_modules/.bin, so the
+      # default `pnpm install` step must run first (left un-overridden).
+      # grunt release:dev then does its OWN composer install (--no-dev) and a
+      # second pnpm install internally (see Gruntfile.js) -- so we skip this
+      # workflow's separate composer step to avoid doing it twice.
+      composer-install: false
+      build-command: pnpm exec grunt release:dev
+      zip-glob: 'release/*.zip'
+      public-base-url: https://themegrill-pr-artifacts.s3.amazonaws.com
+      s3-region: us-east-1
+    secrets: inherit

--- a/.github/workflows/pr-build-zip.yml
+++ b/.github/workflows/pr-build-zip.yml
@@ -21,6 +21,7 @@ jobs:
       composer-install: false
       build-command: pnpm exec grunt release:dev
       zip-glob: 'release/*.zip'
+      artifacts-bucket: themegrill-pr-artifacts
       public-base-url: https://themegrill-pr-artifacts.s3.amazonaws.com
       s3-region: us-east-1
     secrets: inherit

--- a/.github/workflows/pr-build-zip.yml
+++ b/.github/workflows/pr-build-zip.yml
@@ -3,7 +3,7 @@ name: Build Testable ZIP
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [master]
+    branches: [develop]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Adds a testable build ZIP + PR comment on every non-draft PR, via the shared reusable workflow in wpeverest/.github.

Calls `grunt release:dev` directly (it already handles composer install and pnpm install internally), uploads the resulting zip to S3, and posts/updates one PR comment with a direct download link — no login required, installs straight into WordPress.