### PR TITLE
Fix generic error when creating a member with a duplicate email

### DIFF
--- a/modules/membership/includes/Admin/Controllers/MembersController.php
+++ b/modules/membership/includes/Admin/Controllers/MembersController.php
@@ -78,6 +78,13 @@ class MembersController {
 		$members_data = $members_service->prepare_members_data( $data );
 		$member       = $this->members->create( $members_data ); // first create the member themselves.
 
+		if ( is_wp_error( $member ) ) {
+			return array(
+				'status'  => false,
+				'message' => $member->get_error_message(),
+			);
+		}
+
 		if ( $member->ID ) {
 
 			$data = array(
@@ -107,6 +114,16 @@ class MembersController {
 				$members_data = $members_service->prepare_members_data( $data, 'frontend' );
 
 				$member = $this->members->create( $members_data ); // first create the member themselves.
+
+				if ( is_wp_error( $member ) ) {
+					$this->members->wpdb()->query( 'ROLLBACK' );
+
+					return array(
+						'status'  => false,
+						'message' => $member->get_error_message(),
+					);
+				}
+
 				if ( $member->ID ) {
 					$subscription_service = new SubscriptionService();
 					$subscription_data    = $subscription_service->prepare_subscription_data( $members_data, $member );

--- a/modules/membership/includes/Admin/Repositories/MembersRepository.php
+++ b/modules/membership/includes/Admin/Repositories/MembersRepository.php
@@ -27,10 +27,16 @@ class MembersRepository extends BaseRepository implements MembersInterface {
 	 *
 	 * @param $data
 	 *
-	 * @return false|\WP_User
+	 * @return false|\WP_Error|\WP_User
 	 */
 	public function create( $data ) {
 		$new_user_id = wp_insert_user( $data['user_data'] );
+
+		// A WP_Error is truthy, so return it before it becomes a WP_User with ID 0.
+		if ( is_wp_error( $new_user_id ) ) {
+			return $new_user_id;
+		}
+
 		if ( $new_user_id ) {
 			$user = new \WP_User( $new_user_id );
 			update_user_meta( $new_user_id, 'ur_registration_source', 'membership' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adding a member from the admin with an email that already belongs to an existing user showed `Sorry! There was an unexpected error while saving the members data .` instead of telling the admin the email was already in use.

WordPress actually rejects the duplicate correctly and returns a clear, already-translated message. The plugin was discarding it.

**Root cause**

`wp_insert_user()` returns a `WP_Error` for an existing email or username. `MembersRepository::create()` guarded on truthiness only:

```php
$new_user_id = wp_insert_user( $data['user_data'] );
if ( $new_user_id ) {          // a WP_Error object is truthy — passes
    $user = new \WP_User( $new_user_id );
```

A `WP_Error` is an object, so it is truthy. It passed the guard and was used to construct a `WP_User`, which is non-numeric and therefore resolved to ID `0`. `MembersController::create_members_admin()` then failed its `if ( $member->ID )` check, had no `else`, and fell off the end returning `null`. `AJAX::create_member()` saw a response with no `message` key and printed its generic fallback string.

Runtime trace before the fix:

```
wp_insert_user_returns     = WP_Error(existing_user_email): "Sorry, that email address is already used!"
repository_create_returns  = WP_User with ID = 0
controller_returns         = NULL
message_shown_to_admin     = "Sorry! There was an unexpected error while saving the members data."
```

**Changes**

- `MembersRepository::create()` — return the `WP_Error` instead of letting it become a `WP_User` with ID 0.
- `MembersController::create_members_admin()` — return `get_error_message()` so the AJAX layer has a real message.
- `MembersController::create_members_public()` — same guard for frontend registration, which swallowed the error the same way. Rolls back first, since it runs inside a transaction.

Duplicate **username** was broken by the same mechanism and is fixed by the same guards.

```mermaid
flowchart TD
    A["Admin submits new member<br/>with an existing email"] --> B["wp_insert_user()"]
    B --> C["returns WP_Error<br/>existing_user_email"]

    C --> D{"MembersRepository::create()"}
    D -->|"before: if ( $new_user_id )<br/>WP_Error is truthy"| E["new WP_User( WP_Error )<br/>ID = 0"]
    D -->|"after: is_wp_error() guard"| F["return the WP_Error"]

    E --> G["controller: if ( $member->ID )<br/>fails, no else"]
    G --> H["returns NULL"]
    H --> I["AJAX generic fallback<br/>'unexpected error while saving<br/>the members data'"]

    F --> J["controller: is_wp_error() guard<br/>returns get_error_message()"]
    J --> K["'Sorry, that email address<br/>is already used!'"]

    style I fill:#ffdddd,stroke:#cc0000,color:#000
    style K fill:#ddffdd,stroke:#00aa00,color:#000
    style E fill:#ffdddd,stroke:#cc0000,color:#000
```

Closes wpeverest/user-registration-pro#1512

### How to test the changes in this Pull Request:

1. Note the email address of any existing user on the site.
2. Go to **User Registration & Membership → Memberships → Members → Create New Member**.
3. Fill in a **new, unused username**, and paste the **existing user's email** into the email field. Pick any membership and save.
4. **Expected:** `Sorry, that email address is already used!`
   **Before this fix:** `Sorry! There was an unexpected error while saving the members data .`
5. Repeat with an **existing username** and a fresh unused email.
   **Expected:** `Sorry, that username already exists!`
6. Regression — create a member with a genuinely new username and email. It must still be created successfully and appear in the Members list.
7. Frontend regression — register through a form that includes a membership field, once with a duplicate email (should now report the real reason, and must not leave a half-created user behind) and once with fresh details (must still succeed).

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

Verified locally against the real controller. Duplicate email now returns `Sorry, that email address is already used!`, duplicate username returns `Sorry, that username already exists!`, and creating a brand-new member still succeeds.

**Noted, not fixed here (out of scope):** `MembersRepository::update()` has the same truthy-`WP_Error` flaw, so editing a member to a duplicate email fails silently. Its only caller discards the return value entirely, so it needs the caller reworked too — worth a separate issue.

### Changelog entry

> Fix - Show the actual reason instead of a generic error when creating a member with an email or username that is already in use.
