### PR TITLE
Use hash_equals() for email confirmation, approval and denial token comparisons

### DIFF
--- a/includes/class-ur-email-approval.php
+++ b/includes/class-ur-email-approval.php
@@ -49,7 +49,7 @@ class UR_Email_Approval {
 
 				$saved_token = get_user_meta( $user_id, 'ur_confirm_approval_token', true );
 
-			if ( $ur_approval_token_raw === $saved_token ) {
+			if ( hash_equals( (string) $saved_token, $ur_approval_token_raw ) ) {
 				$user_manager = new UR_Admin_User_Manager( $user_id );
 				$user_manager->save_status( UR_Admin_User_Manager::APPROVED, true );
 
@@ -94,7 +94,7 @@ class UR_Email_Approval {
 
 			$saved_token = get_user_meta( $user_id, 'ur_confirm_denial_token', true );
 
-			if ( $ur_denial_token_raw === $saved_token ) {
+			if ( hash_equals( (string) $saved_token, $ur_denial_token_raw ) ) {
 				$user_manager = new UR_Admin_User_Manager( $user_id );
 				$user_manager->save_status( UR_Admin_User_Manager::DENIED, true );
 

--- a/includes/class-ur-email-confirmation.php
+++ b/includes/class-ur-email-confirmation.php
@@ -215,6 +215,12 @@ class UR_Email_Confirmation {
 		} else {
 			$ur_token_raw = sanitize_text_field( wp_unslash( $_GET['ur_token'] ) );
 			$ur_token     = str_split( $ur_token_raw, 50 );
+
+			// A token of 50 characters or fewer has no second chunk, so there is nothing to decrypt.
+			if ( count( $ur_token ) < 2 ) {
+				return;
+			}
+
 			$token_string = $ur_token[1];
 
 			if ( 2 < count( $ur_token ) ) {

--- a/includes/class-ur-email-confirmation.php
+++ b/includes/class-ur-email-confirmation.php
@@ -213,7 +213,8 @@ class UR_Email_Confirmation {
 		if ( ! isset( $_GET['ur_token'] ) || empty( $_GET['ur_token'] ) ) {
 			return;
 		} else {
-			$ur_token     = str_split( sanitize_text_field( wp_unslash( $_GET['ur_token'] ) ), 50 );
+			$ur_token_raw = sanitize_text_field( wp_unslash( $_GET['ur_token'] ) );
+			$ur_token     = str_split( $ur_token_raw, 50 );
 			$token_string = $ur_token[1];
 
 			if ( 2 < count( $ur_token ) ) {
@@ -234,7 +235,7 @@ class UR_Email_Confirmation {
 			// Check if the token matches the token value stored in db.
 			$login_option = ur_get_user_login_option( $user_id );
 
-			if ( $user_token === $_GET['ur_token'] && ( 'email_confirmation' === $login_option || 'admin_approval_after_email_confirmation' === $login_option ) ) {
+			if ( hash_equals( (string) $user_token, $ur_token_raw ) && ( 'email_confirmation' === $login_option || 'admin_approval_after_email_confirmation' === $login_option ) ) {
 				$token_expiration_duration = 24 * 60 * 60;
 				/**
 				 * Filter hook to modify the token expiration duration.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Three verification tokens were compared with `===`, which is not timing-safe:

* `class-ur-email-confirmation.php` — the email confirmation token. This one is reached from a **public, unauthenticated** endpoint (`template_redirect` on `?ur_token=`), where the token is the only secret guarding the confirmation.
* `class-ur-email-approval.php` — the approval and denial tokens. Both are behind `current_user_can( 'edit_users' )`, so the practical risk is much lower, but they are the same pattern.

All three now use `hash_equals()`.

The email confirmation check also compared against the raw `$_GET['ur_token']` rather than the sanitized and unslashed copy taken twenty lines earlier. Tokens are base64 of AES-256-CBC output, so in practice slashing does not alter them, but the inconsistency is easy to trip over later — the comparison now uses the sanitized value.

Raising this against the free plugin rather than Pro because these files are byte-identical in both trees and sync from here, so fixing it upstream is what keeps the two in step.

### How to test the changes in this Pull Request:

1. Set a form's login option to "Email Confirmation" and register a user. Grab their `ur_confirm_email_token` user meta.
2. Visit the site with `?ur_token=<token with one character changed>` — the user's `ur_confirm_email` meta stays `0`.
3. Visit with the correct `?ur_token=` — `ur_confirm_email` becomes `1`, the token meta is cleared, and the confirmation email/redirect behaves as before.
4. Set a form's login option to "Admin Approval" and register a user. As an administrator, hit wp-admin with `?ur_approval_token=` — a modified token leaves `ur_user_status` at `0`, the correct one sets it to `1` and redirects to `users.php`.
5. Repeat with `?ur_denial_token=` — the correct token sets `ur_user_status` to `-1`.
6. Confirm an unauthenticated request carrying a valid approval token still does nothing.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

Verified manually against a live install — all six cases above pass, with no fatals or uncaught errors in `debug.log`. Because the free plugin is inactive when Pro is running, the files were temporarily mirrored into the Pro tree to exercise them on a live site, then reverted.

Found while working on wpeverest/user-registration-pro#1460, which recommends `hash_equals()` for OTP comparison; these are the same bug class elsewhere in the codebase. There is no separate issue for it.

### Changelog entry

> Fix - Use timing-safe comparison for email confirmation, admin approval and denial tokens.
