### PR TITLE
Sync edit-team template: scope the nonce to the submitted team id

### DIFF
--- a/templates/myaccount/edit-team.php
+++ b/templates/myaccount/edit-team.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.wpuserregistration.com/docs/how-to-edit-user-registration-template-files-such-as-login-form/
  * @package UserRegistration/Templates
- * @version 1.0.0
+ * @version 1.0.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -24,7 +24,7 @@ if ( empty( $team ) ) {
 	return;
 }
 
-$team_id   = $team['ID'] ?? '';
+$team_id   = absint( $team['ID'] ?? 0 );
 $team_name = $team['team_name'] ?? '';
 $members   = $team['meta']['urm_member_emails'] ?? [];
 $leader_id = (int) ( $team['meta']['urm_team_leader_id'] ?? 0 );
@@ -70,7 +70,7 @@ $ordered_emails = array_merge( $ordered_emails, $other_emails );
 		<form class="user-registration-EditTeam ur-edit-team-form" method="post" action="">
 			<div class="ur-form-row" style="display: block;">
 				<div class="ur-form-grid">
-					<?php wp_nonce_field( 'ur_edit_team_nonce', 'ur_edit_team_nonce' ); ?>
+					<?php wp_nonce_field( 'ur_edit_team_' . $team_id, 'ur_edit_team_nonce' ); ?>
 					<input type="hidden" name="team_id" value="<?php esc_attr_e( $team_id ); ?>" required>
 					<input type="hidden" name="invited_member_emails">
 					<input type="hidden" name="existing_member_emails" value="<?php esc_attr_e( implode( ',', $members ) ); ?>">

--- a/templates/myaccount/edit-team.php
+++ b/templates/myaccount/edit-team.php
@@ -67,15 +67,13 @@ $ordered_emails = array_merge( $ordered_emails, $other_emails );
 			}
 			?>
 		</div>
-		<form class="user-registration-EditTeam ur-edit-team-form" method="post" action="">
+		<form class="user-registration-EditTeam ur-edit-team-form" method="post" action="" data-max-seats="<?php echo esc_attr( $team['meta']['urm_team_seats'] ?? 0 ); ?>">
 			<div class="ur-form-row" style="display: block;">
 				<div class="ur-form-grid">
 					<?php wp_nonce_field( 'ur_edit_team_' . $team_id, 'ur_edit_team_nonce' ); ?>
 					<input type="hidden" name="team_id" value="<?php esc_attr_e( $team_id ); ?>" required>
 					<input type="hidden" name="invited_member_emails">
 					<input type="hidden" name="existing_member_emails" value="<?php esc_attr_e( implode( ',', $members ) ); ?>">
-					<input type="hidden" name="members_id" value="<?php esc_attr_e( implode( ',', $team['meta']['urm_member_ids'] ?? [] ) ); ?>">
-					<input type="hidden" name="max_seats" value="<?php esc_attr_e( $team['meta']['urm_team_seats'] ?? 0 ); ?>">
 
 					<div class="user-registration-form-row user-registration-form-row--wide form-row form-row-wide">
 						<label for="team_name" class="ur-label">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This is the **sync half** of a security fix. The real fix lives in the Pro repo: wpeverest/user-registration-pro#1526 (Team Membership IDOR, wpeverest/user-registration-pro#1497).

`templates/myaccount/edit-team.php` is byte-identical in this repo and in Pro, and it is kept in sync automatically. The Pro fix had to change that template, so the same changes have to land here too — otherwise the next sync would quietly revert them.

**What changed in the template:**

1. The security nonce is now tied to the specific team being edited — `wp_nonce_field( 'ur_edit_team_' . $team_id, ... )` instead of one shared name for every team.
2. `$team_id` is now run through `absint()`. This matters: it used to default to an empty string, which would have produced a nonce name of `ur_edit_team_` while the Pro handler expects `ur_edit_team_0` — a silent mismatch.
3. The `members_id` and `max_seats` hidden inputs are removed. The Pro handler no longer reads either — the seat limit comes from `urm_team_seats` and the member IDs are resolved from the submitted emails — so leaving them in the form only invited someone to wire them back up.
4. The seat count moved to `data-max-seats` on the `<form>`. The frontend script read `max_seats` for its client-side cap, so the value still has to reach the page; as an attribute it is available to the script but is not submitted.
5. Template `@version` bumped 1.0.0 → 1.0.1, as required when an overridable template changes.

**There is no behaviour change in this repo.** The Team Membership feature is Pro-only, so nothing in this plugin reads this template today. This PR exists purely to keep the two copies identical.

### How to test the changes in this Pull Request:

1. Confirm this template is still byte-identical to the Pro copy on wpeverest/user-registration-pro#1526.
2. Confirm the free plugin has no regressions — this template is not used by any feature in this repo.
3. The actual security testing steps are in wpeverest/user-registration-pro#1526.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

Not breaking in this repo, since the template is unused here. It *is* a breaking change for Pro sites that override this template in their theme — see the note on wpeverest/user-registration-pro#1526.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

Verified the file is byte-identical to the Pro branch's copy (`cmp` reports no differences) and passes `php -l`. PHPCS shows no new violations, only removals — against the `WordPress` standard, 13 on `develop` and 10 here; everything remaining pre-dates this PR. (Measured with the `WordPress` standard rather than the project ruleset, which needs `PHPCompatibility` and `WPEverest-Core` installed; the earlier 14 → 13 figure in this PR's history came from the project ruleset, so the two counts are not comparable.)

**Merge order:** this should land together with, or just after, wpeverest/user-registration-pro#1526 — on its own it does nothing.

### Changelog entry

> Fix: Team Membership - scope the Edit Team form nonce to the team being edited and drop the unused seat-limit and member-ID inputs (template sync with Pro).

