### PR TITLE
Sync smart tags: add the force logout URL tag

### DIFF
--- a/includes/class-ur-smart-tags.php
+++ b/includes/class-ur-smart-tags.php
@@ -114,6 +114,7 @@ class UR_Smart_Tags {
 			'{{username}}'               => esc_html__( 'User Name', 'user-registration' ),
 			'{{email}}'                  => esc_html__( 'Email', 'user-registration' ),
 			'{{ur_login}}'               => esc_html__( 'UR Login', 'user-registration' ),
+			'{{force_logout_url}}'       => esc_html__( 'Force Logout URL', 'user-registration' ),
 			'{{all_fields}}'             => esc_html__( 'All Fields', 'user-registration' ),
 			'{{auto_pass}}'              => esc_html__( 'Auto Pass', 'user-registration' ),
 			'{{user_roles}}'             => esc_html__( 'User Roles', 'user-registration' ),
@@ -288,6 +289,12 @@ class UR_Smart_Tags {
 						$ur_login = ( get_home_url() !== $ur_login_or_account_page ) ? $ur_login_or_account_page : wp_login_url();
 						$ur_login = str_replace( get_home_url() . '/', '', $ur_login );
 						$content  = str_replace( '{{' . $other_tag . '}}', $ur_login, $content );
+						break;
+
+					case 'force_logout_url':
+						// Only the prevent concurrent login email supplies this through $values; anywhere
+						// else there is no link to give, so drop the tag rather than print it.
+						$content = str_replace( '{{' . $other_tag . '}}', '', $content );
 						break;
 
 					case 'auto_pass':


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This is the **sync half** of a security fix. The real fix lives in the Pro repo: wpeverest/user-registration-pro#1522 (unauthenticated force-logout, wpeverest/user-registration-pro#1496).

`includes/class-ur-smart-tags.php` is byte-identical in this repo and in Pro. The Pro fix adds a `{{force_logout_url}}` smart tag, so the same change has to land here too — otherwise the next sync would quietly revert it and the Pro email would emit a raw, unresolved tag.

**What changed (7 lines):**

1. `{{force_logout_url}}` registered in `ur_authenticated_parsable_smart_tags_list()`, so it appears in the email editor's tag picker.
2. A `case 'force_logout_url':` in the tag processor that resolves the tag to an empty string. Only the Pro *prevent concurrent login* email supplies a value for it (through `$values`); everywhere else there is no link to give, and without this case the literal `{{force_logout_url}}` would survive into a sent email.

**There is no behaviour change in this repo.** The force-logout feature is Pro-only, so nothing here ever supplies a value — the tag resolves to an empty string, which is the same as any other context-specific tag used outside its own email. This PR exists purely to keep the two copies identical.

### How to test the changes in this Pull Request:

1. Confirm this file is still byte-identical to the Pro copy on wpeverest/user-registration-pro#1522.
2. In the free plugin, put `{{force_logout_url}}` into any email template and send that email — the tag must vanish, not appear literally in the message.
3. The actual security testing steps are on wpeverest/user-registration-pro#1522.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

Verified byte-identical to the Pro branch's copy (`cmp` reports no differences) and passes `php -l`. PHPCS shows no new violations: measured with the `WordPress` standard, 61 on `develop` and 60 here — the change removes one and adds none. Measured with that standard rather than the project ruleset, which needs `PHPCompatibility` and `WPEverest-Core` installed, so these counts are not comparable to project-ruleset numbers.

**Merge order:** this should land together with, or just after, wpeverest/user-registration-pro#1522 — on its own it does nothing.

### Changelog entry

> Add: `{{force_logout_url}}` smart tag (used by the Pro prevent concurrent login email).
