### PR TITLE
#1514 Fix - Enforce content restriction on WordPress core REST API responses

### DIFF
--- a/modules/content-drip/includes/Frontend.php
+++ b/modules/content-drip/includes/Frontend.php
@@ -162,6 +162,99 @@ class Frontend {
 		return $waiting;
 	}
 
+	/**
+	 * See if the given post is still waiting for its content drip to release.
+	 *
+	 * Decision only counterpart of apply_content_drip(), safe to call outside the
+	 * template rendering flow.
+	 *
+	 * @param object $target_post Post to check against.
+	 *
+	 * @return bool
+	 * @since 5.2.8
+	 */
+	public static function is_drip_pending( $target_post ) {
+		if ( ! is_object( $target_post ) || ! get_current_user_id() ) {
+			return false;
+		}
+
+		if ( ! class_exists( '\WPEverest\URMembership\Admin\Repositories\MembersRepository' ) ) {
+			return false;
+		}
+
+		$members_repository = new \WPEverest\URMembership\Admin\Repositories\MembersRepository();
+		$memberships        = $members_repository->get_member_membership_by_id( get_current_user_id() );
+
+		if ( empty( $memberships ) ) {
+			return false;
+		}
+
+		$access_rule_posts = function_exists( 'urcr_get_published_access_rules' ) ? urcr_get_published_access_rules() : array();
+
+		foreach ( $access_rule_posts as $access_rule_post ) {
+			$access_rule = json_decode( $access_rule_post->post_content, true );
+
+			if ( ! function_exists( 'urcr_is_access_rule_evaluable' ) || ! urcr_is_access_rule_evaluable( $access_rule ) ) {
+				continue;
+			}
+
+			// Whole site targets without a drip configuration never delay a single post.
+			$target_contents = array_filter(
+				$access_rule['target_contents'],
+				function ( $target_content ) {
+					return ! isset( $target_content['type'] ) || 'whole_site' !== $target_content['type'] || ! empty( $target_content['drip'] );
+				}
+			);
+
+			if ( ! self::is_target_post( $target_contents, $target_post ) ) {
+				continue;
+			}
+
+			foreach ( $target_contents as $content ) {
+				if ( empty( $content['drip']['activeType'] ) || empty( $content['drip']['value'] ) ) {
+					continue;
+				}
+
+				$active_type             = $content['drip']['activeType'];
+				$value                   = $content['drip']['value'];
+				$earliest_drip_timestamp = null;
+
+				foreach ( $memberships as $membership ) {
+					$drip_timestamp = null;
+
+					if ( 'fixed_date' === $active_type ) {
+						$date = isset( $value['fixed_date']['date'] ) ? $value['fixed_date']['date'] : '';
+						$time = isset( $value['fixed_date']['time'] ) ? $value['fixed_date']['time'] : '';
+
+						if ( empty( $date ) || empty( $time ) ) {
+							continue;
+						}
+
+						$drip_timestamp = strtotime( $date . ' ' . $time );
+					} elseif ( 'days_after' === $active_type ) {
+						$days_after     = isset( $value['days_after']['days'] ) ? $value['days_after']['days'] : 0;
+						$drip_timestamp = strtotime( "+{$days_after} days", strtotime( $membership['start_date'] ) );
+					}
+
+					if ( null === $drip_timestamp ) {
+						continue;
+					}
+
+					if ( is_null( $earliest_drip_timestamp ) || $drip_timestamp < $earliest_drip_timestamp ) {
+						$earliest_drip_timestamp = $drip_timestamp;
+					}
+				}
+
+				// phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested -- Kept identical to apply_content_drip() so both paths release content at the same moment.
+				if ( ! is_null( $earliest_drip_timestamp ) && current_time( 'timestamp' ) < $earliest_drip_timestamp ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
 	public static function show_content_drip_message( $drip, &$target_post = null ) {
 		global $post;
 		if ( ! is_object( $target_post ) ) {

--- a/modules/content-drip/includes/Frontend.php
+++ b/modules/content-drip/includes/Frontend.php
@@ -182,8 +182,17 @@ class Frontend {
 			return false;
 		}
 
-		$members_repository = new \WPEverest\URMembership\Admin\Repositories\MembersRepository();
-		$memberships        = $members_repository->get_member_membership_by_id( get_current_user_id() );
+		// Cached per user because a REST collection calls this once for every item prepared.
+		static $memberships_by_user = array();
+
+		$user_id = get_current_user_id();
+
+		if ( ! isset( $memberships_by_user[ $user_id ] ) ) {
+			$members_repository              = new \WPEverest\URMembership\Admin\Repositories\MembersRepository();
+			$memberships_by_user[ $user_id ] = $members_repository->get_member_membership_by_id( $user_id );
+		}
+
+		$memberships = $memberships_by_user[ $user_id ];
 
 		if ( empty( $memberships ) ) {
 			return false;
@@ -202,7 +211,7 @@ class Frontend {
 			$target_contents = array_filter(
 				$access_rule['target_contents'],
 				function ( $target_content ) {
-					return ! isset( $target_content['type'] ) || 'whole_site' !== $target_content['type'] || ! empty( $target_content['drip'] );
+					return ! isset( $target_content['type'] ) || 'whole_site' !== $target_content['type'] || empty( $target_content['drip'] );
 				}
 			);
 

--- a/modules/content-drip/includes/Frontend.php
+++ b/modules/content-drip/includes/Frontend.php
@@ -30,7 +30,6 @@ class Frontend {
 	private function init_hooks() {
 		// add_action( 'wp_enqueue_scripts', array( $this, 'load_scripts' ), 10, 2 );
 	}
-
 	/**
 	 * Enqueue styles for the course portal page.
 	 *

--- a/modules/content-restriction/class-urcr-rest-restriction.php
+++ b/modules/content-restriction/class-urcr-rest-restriction.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Enforce content restriction on WordPress core REST API responses.
+ *
+ * The template based restriction flow hangs off template_redirect and
+ * template_include, neither of which run during a REST request, so restricted
+ * content would otherwise be served in full to anonymous requesters.
+ *
+ * @since 5.2.8
+ *
+ * @package UserRegistrationContentRestriction/Classes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * URCR_REST_Restriction Class
+ */
+class URCR_REST_Restriction {
+
+	/**
+	 * Hook in the REST response filters.
+	 *
+	 * @since 5.2.8
+	 */
+	public static function init() {
+		add_action( 'rest_api_init', array( __CLASS__, 'register_response_filters' ) );
+	}
+
+	/**
+	 * Register a prepare filter for every publicly readable post type.
+	 *
+	 * @since 5.2.8
+	 */
+	public static function register_response_filters() {
+		$post_types = get_post_types(
+			array(
+				'public'       => true,
+				'show_in_rest' => true,
+			)
+		);
+
+		/**
+		 * Filter the post types whose REST responses are checked against content restriction.
+		 *
+		 * @since 5.2.8
+		 *
+		 * @param array $post_types Post type names.
+		 */
+		$post_types = apply_filters( 'urcr_rest_restricted_post_types', $post_types );
+
+		foreach ( (array) $post_types as $post_type ) {
+			add_filter( 'rest_prepare_' . $post_type, array( __CLASS__, 'restrict_response' ), PHP_INT_MAX, 3 );
+		}
+	}
+
+	/**
+	 * Strip the content of a restricted post from its REST response.
+	 *
+	 * @since 5.2.8
+	 *
+	 * @param WP_REST_Response $response Response object.
+	 * @param WP_Post          $post     Post being prepared.
+	 * @param WP_REST_Request  $request  Request object.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public static function restrict_response( $response, $post, $request ) {
+		if ( ! $response instanceof WP_REST_Response || ! $post instanceof WP_Post ) {
+			return $response;
+		}
+
+		if ( ! function_exists( 'urcr_is_content_access_granted' ) || urcr_is_content_access_granted( $post ) ) {
+			return $response;
+		}
+
+		$data = $response->get_data();
+
+		if ( ! is_array( $data ) ) {
+			return $response;
+		}
+
+		// Content bearing fields across posts, pages and attachments.
+		foreach ( array( 'content', 'excerpt', 'description', 'caption' ) as $field ) {
+			if ( ! isset( $data[ $field ] ) ) {
+				continue;
+			}
+
+			$data[ $field ] = array(
+				'rendered'  => '',
+				'protected' => true,
+			);
+		}
+
+		foreach ( array( 'source_url', 'media_details' ) as $field ) {
+			if ( isset( $data[ $field ] ) ) {
+				$data[ $field ] = is_array( $data[ $field ] ) ? array() : '';
+			}
+		}
+
+		/**
+		 * Filter the REST response served for a restricted post.
+		 *
+		 * @since 5.2.8
+		 *
+		 * @param array           $data    Sanitized response data.
+		 * @param WP_Post         $post    Restricted post.
+		 * @param WP_REST_Request $request Request object.
+		 */
+		$data = apply_filters( 'urcr_rest_restricted_response_data', $data, $post, $request );
+
+		$response->set_data( $data );
+
+		return $response;
+	}
+}
+
+URCR_REST_Restriction::init();

--- a/modules/content-restriction/class-urcr-rest-restriction.php
+++ b/modules/content-restriction/class-urcr-rest-restriction.php
@@ -98,6 +98,11 @@ class URCR_REST_Restriction {
 			}
 		}
 
+		// An attachment's guid is its file URL, so it leaks the media source on its own.
+		if ( 'attachment' === $post->post_type && isset( $data['guid'] ) ) {
+			$data['guid'] = array( 'rendered' => '' );
+		}
+
 		/**
 		 * Filter the REST response served for a restricted post.
 		 *

--- a/modules/content-restriction/functions-urcr-core.php
+++ b/modules/content-restriction/functions-urcr-core.php
@@ -1817,22 +1817,39 @@ function urcr_has_whole_site_access_rule() {
 /**
  * Resolve the access rules that apply to the given post.
  *
- * Mirrors the decision taken by URCR_Frontend::advanced_restriction_with_access_rules()
- * and URCR_Frontend::restrict_whole_site() without applying any restriction.
+ * Whole site rules and post targeted rules are resolved as two independent passes,
+ * because the front end enforces them through two independent hooks:
+ * URCR_Frontend::advanced_restriction_with_access_rules() only ever sees post targeted
+ * rules, while URCR_Frontend::restrict_whole_site() handles the whole site ones. A
+ * restriction from either pass wins, so a grant in one pass must never cancel a
+ * restriction found by the other. Nothing is applied here, this only decides.
  *
  * @param object $target_post Post to check against.
  *
  * @return array {
- *     @type bool       $granted  Whether a rule explicitly granted access.
- *     @type array|null $rule     The rule that restricts access, when one matched.
- *     @type bool       $matched  Whether any rule targeted the post at all.
+ *     Resolution of each pass, keyed 'whole_site' and 'post'.
+ *
+ *     @type array $... {
+ *         @type bool       $granted Whether a rule in this pass explicitly granted access.
+ *         @type array|null $rule    The rule that restricts access, when one matched.
+ *         @type bool       $matched Whether any rule in this pass targeted the post at all.
+ *     }
  * }
  * @since 5.2.8
  */
 function urcr_resolve_access_rules( $target_post ) {
-	$granted          = false;
-	$matched          = false;
-	$restriction_rule = null;
+	$resolved = array(
+		'whole_site' => array(
+			'granted' => false,
+			'rule'    => null,
+			'matched' => false,
+		),
+		'post'       => array(
+			'granted' => false,
+			'rule'    => null,
+			'matched' => false,
+		),
+	);
 
 	foreach ( urcr_get_published_access_rules() as $access_rule_post ) {
 		$access_rule = json_decode( $access_rule_post->post_content, true );
@@ -1847,31 +1864,27 @@ function urcr_resolve_access_rules( $target_post ) {
 		 * without a non-empty 'value', and both the legacy migration and the membership rule
 		 * save path build whole site targets with no 'value' at all.
 		 */
-		$target_types = wp_list_pluck( $access_rule['target_contents'], 'type' );
-		$is_target    = in_array( 'whole_site', $target_types, true )
-			|| true === urcr_is_target_post( $access_rule['target_contents'], $target_post );
-
-		if ( ! $is_target ) {
+		if ( in_array( 'whole_site', wp_list_pluck( $access_rule['target_contents'], 'type' ), true ) ) {
+			$pass = 'whole_site';
+		} elseif ( true === urcr_is_target_post( $access_rule['target_contents'], $target_post ) ) {
+			$pass = 'post';
+		} else {
 			continue;
 		}
 
-		$matched = true;
+		$resolved[ $pass ]['matched'] = true;
 
 		$should_allow_access = urcr_is_allow_access( $access_rule['logic_map'], $target_post );
 		$access_control      = ! empty( $access_rule['actions'][0]['access_control'] ) ? $access_rule['actions'][0]['access_control'] : 'access';
 
 		if ( ( $should_allow_access && 'access' === $access_control ) || ( ! $should_allow_access && 'restrict' === $access_control ) ) {
-			$granted = true;
+			$resolved[ $pass ]['granted'] = true;
 		} else {
-			$restriction_rule = $access_rule;
+			$resolved[ $pass ]['rule'] = $access_rule;
 		}
 	}
 
-	return array(
-		'granted' => $granted,
-		'rule'    => $restriction_rule,
-		'matched' => $matched,
-	);
+	return $resolved;
 }
 
 /**
@@ -1965,14 +1978,32 @@ function urcr_is_content_access_granted( $target_post ) {
 	}
 
 	$resolved_rules = urcr_resolve_access_rules( $target_post );
+	$whole_site     = $resolved_rules['whole_site'];
+	$post_targeted  = $resolved_rules['post'];
 
-	// A granting rule always wins over a restricting one.
-	if ( ! $resolved_rules['granted'] && null !== $resolved_rules['rule'] ) {
+	/*
+	 * Post targeted rules, as enforced by
+	 * URCR_Frontend::advanced_restriction_with_access_rules(). Within this pass a granting
+	 * rule wins over a restricting one, but a whole site grant does not reach it.
+	 */
+	if ( ! $post_targeted['granted'] && null !== $post_targeted['rule'] ) {
 		return false;
 	}
 
+	/*
+	 * Whole site rules, as enforced separately by URCR_Frontend::restrict_whole_site().
+	 * That method returns early for a whole site grant and then, before applying the
+	 * restriction, walks the post targeted rules once more and bails out on a grant there
+	 * too, so either grant lifts a whole site restriction.
+	 */
+	if ( ! $whole_site['granted'] && ! $post_targeted['granted'] && null !== $whole_site['rule'] ) {
+		return false;
+	}
+
+	$rules_granted_access = $whole_site['granted'] || $post_targeted['granted'];
+
 	// Whole site members only, applied when no access rule covers the whole site.
-	if ( ! $resolved_rules['granted']
+	if ( ! $rules_granted_access
 		&& ur_string_to_bool( get_option( 'user_registration_content_restriction_whole_site_access', false ) )
 		&& ! urcr_has_whole_site_access_rule() ) {
 

--- a/modules/content-restriction/functions-urcr-core.php
+++ b/modules/content-restriction/functions-urcr-core.php
@@ -1786,6 +1786,14 @@ function urcr_is_access_rule_evaluable( $access_rule ) {
  * @since 5.2.8
  */
 function urcr_has_whole_site_access_rule() {
+	static $has_whole_site_rule = null;
+
+	if ( null !== $has_whole_site_rule ) {
+		return $has_whole_site_rule;
+	}
+
+	$has_whole_site_rule = false;
+
 	foreach ( urcr_get_published_access_rules() as $access_rule_post ) {
 		$access_rule = json_decode( $access_rule_post->post_content, true );
 
@@ -1798,11 +1806,12 @@ function urcr_has_whole_site_access_rule() {
 		}
 
 		if ( in_array( 'whole_site', wp_list_pluck( $access_rule['target_contents'], 'type' ), true ) ) {
-			return true;
+			$has_whole_site_rule = true;
+			break;
 		}
 	}
 
-	return false;
+	return $has_whole_site_rule;
 }
 
 /**
@@ -1832,7 +1841,17 @@ function urcr_resolve_access_rules( $target_post ) {
 			continue;
 		}
 
-		if ( true !== urcr_is_target_post( $access_rule['target_contents'], $target_post ) ) {
+		/*
+		 * Whole site targets are matched by type, exactly as
+		 * URCR_Frontend::restrict_whole_site() does. urcr_is_target_post() skips any target
+		 * without a non-empty 'value', and both the legacy migration and the membership rule
+		 * save path build whole site targets with no 'value' at all.
+		 */
+		$target_types = wp_list_pluck( $access_rule['target_contents'], 'type' );
+		$is_target    = in_array( 'whole_site', $target_types, true )
+			|| true === urcr_is_target_post( $access_rule['target_contents'], $target_post );
+
+		if ( ! $is_target ) {
 			continue;
 		}
 
@@ -1896,8 +1915,10 @@ function urcr_is_basic_access_granted( $allow_access_to, $allowed_roles, $allowe
 /**
  * See if the current user is allowed to read the given post.
  *
- * Single authorization gate shared by the template based restriction flow and the
- * WordPress core REST API. It only decides, it never applies a restriction.
+ * Authorization gate for the WordPress core REST API. It mirrors the decisions taken by
+ * the template based restriction flow, which still evaluates access inline in
+ * URCR_Frontend, and it only decides, it never applies a restriction. Keep both in step
+ * until the template flow is consolidated onto this function.
  *
  * @param int|object $target_post Post ID or post object to check against.
  *
@@ -1952,8 +1973,8 @@ function urcr_is_content_access_granted( $target_post ) {
 
 	// Whole site members only, applied when no access rule covers the whole site.
 	if ( ! $resolved_rules['granted']
-		&& ! urcr_has_whole_site_access_rule()
-		&& ur_string_to_bool( get_option( 'user_registration_content_restriction_whole_site_access', false ) ) ) {
+		&& ur_string_to_bool( get_option( 'user_registration_content_restriction_whole_site_access', false ) )
+		&& ! urcr_has_whole_site_access_rule() ) {
 
 		$basic_access_granted = urcr_is_basic_access_granted(
 			get_option( 'user_registration_content_restriction_allow_access_to', '0' ),

--- a/modules/content-restriction/functions-urcr-core.php
+++ b/modules/content-restriction/functions-urcr-core.php
@@ -1729,3 +1729,267 @@ function urcr_migrated_global_rule() {
 
 	return ! empty( $posts ) ? json_decode( $posts[0]->post_content, true ) : array();
 }
+
+/**
+ * Get every published access rule.
+ *
+ * @return array List of access rule posts.
+ * @since 5.2.8
+ */
+function urcr_get_published_access_rules() {
+	global $wpdb;
+
+	static $access_rules = null;
+
+	if ( null === $access_rules ) {
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Mirrors URCR_Frontend::get_all_access_rules(); the result is cached in $access_rules for the rest of the request.
+		$access_rules = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT * FROM {$wpdb->posts} WHERE post_type = %s AND post_status = %s",
+				'urcr_access_rule',
+				'publish'
+			)
+		);
+	}
+
+	return $access_rules;
+}
+
+/**
+ * See if the given access rule holds the minimum data required to be evaluated.
+ *
+ * @param mixed $access_rule Decoded access rule.
+ *
+ * @return bool
+ * @since 5.2.8
+ */
+function urcr_is_access_rule_evaluable( $access_rule ) {
+	if ( ! is_array( $access_rule ) ) {
+		return false;
+	}
+
+	if ( empty( $access_rule['logic_map'] ) || empty( $access_rule['target_contents'] ) || empty( $access_rule['actions'] ) ) {
+		return false;
+	}
+
+	if ( ! is_array( $access_rule['logic_map'] ) || empty( $access_rule['logic_map']['conditions'] ) ) {
+		return false;
+	}
+
+	return urcr_is_access_rule_enabled( $access_rule ) && urcr_is_action_specified( $access_rule );
+}
+
+/**
+ * See if any published access rule targets the whole site.
+ *
+ * @return bool
+ * @since 5.2.8
+ */
+function urcr_has_whole_site_access_rule() {
+	foreach ( urcr_get_published_access_rules() as $access_rule_post ) {
+		$access_rule = json_decode( $access_rule_post->post_content, true );
+
+		if ( ! is_array( $access_rule ) || empty( $access_rule['enabled'] ) || empty( $access_rule['target_contents'] ) ) {
+			continue;
+		}
+
+		if ( ! ur_string_to_bool( $access_rule['enabled'] ) || ! is_array( $access_rule['target_contents'] ) ) {
+			continue;
+		}
+
+		if ( in_array( 'whole_site', wp_list_pluck( $access_rule['target_contents'], 'type' ), true ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Resolve the access rules that apply to the given post.
+ *
+ * Mirrors the decision taken by URCR_Frontend::advanced_restriction_with_access_rules()
+ * and URCR_Frontend::restrict_whole_site() without applying any restriction.
+ *
+ * @param object $target_post Post to check against.
+ *
+ * @return array {
+ *     @type bool       $granted  Whether a rule explicitly granted access.
+ *     @type array|null $rule     The rule that restricts access, when one matched.
+ *     @type bool       $matched  Whether any rule targeted the post at all.
+ * }
+ * @since 5.2.8
+ */
+function urcr_resolve_access_rules( $target_post ) {
+	$granted          = false;
+	$matched          = false;
+	$restriction_rule = null;
+
+	foreach ( urcr_get_published_access_rules() as $access_rule_post ) {
+		$access_rule = json_decode( $access_rule_post->post_content, true );
+
+		if ( ! urcr_is_access_rule_evaluable( $access_rule ) ) {
+			continue;
+		}
+
+		if ( true !== urcr_is_target_post( $access_rule['target_contents'], $target_post ) ) {
+			continue;
+		}
+
+		$matched = true;
+
+		$should_allow_access = urcr_is_allow_access( $access_rule['logic_map'], $target_post );
+		$access_control      = ! empty( $access_rule['actions'][0]['access_control'] ) ? $access_rule['actions'][0]['access_control'] : 'access';
+
+		if ( ( $should_allow_access && 'access' === $access_control ) || ( ! $should_allow_access && 'restrict' === $access_control ) ) {
+			$granted = true;
+		} else {
+			$restriction_rule = $access_rule;
+		}
+	}
+
+	return array(
+		'granted' => $granted,
+		'rule'    => $restriction_rule,
+		'matched' => $matched,
+	);
+}
+
+/**
+ * See if the current user satisfies a basic restriction mode.
+ *
+ * @param string $allow_access_to      Allow access mode. 0: logged in users, 1: roles, 2: guests, 3: memberships.
+ * @param array  $allowed_roles        Roles allowed by the mode.
+ * @param array  $allowed_memberships  Memberships allowed by the mode.
+ *
+ * @return bool
+ * @since 5.2.8
+ */
+function urcr_is_basic_access_granted( $allow_access_to, $allowed_roles, $allowed_memberships ) {
+	$current_user_roles = ( is_user_logged_in() && ! empty( wp_get_current_user()->roles ) ) ? (array) wp_get_current_user()->roles : array();
+
+	switch ( (string) $allow_access_to ) {
+		case '0':
+			return is_user_logged_in();
+
+		case '1':
+			if ( ! is_array( $allowed_roles ) ) {
+				return false;
+			}
+
+			return ! empty( array_intersect( $current_user_roles, $allowed_roles ) );
+
+		case '2':
+			return ! is_user_logged_in();
+
+		case '3':
+			if ( ! ur_check_module_activation( 'membership' ) || ! is_array( $allowed_memberships ) ) {
+				return false;
+			}
+
+			return urm_check_user_membership_has_access( $allowed_memberships );
+	}
+
+	return true;
+}
+
+/**
+ * See if the current user is allowed to read the given post.
+ *
+ * Single authorization gate shared by the template based restriction flow and the
+ * WordPress core REST API. It only decides, it never applies a restriction.
+ *
+ * @param int|object $target_post Post ID or post object to check against.
+ *
+ * @return bool True when the content may be read, false when it is restricted.
+ * @since 5.2.8
+ */
+function urcr_is_content_access_granted( $target_post ) {
+	if ( ! ur_string_to_bool( get_option( 'user_registration_content_restriction_enable', true ) ) ) {
+		return true;
+	}
+
+	$target_post = is_object( $target_post ) ? $target_post : get_post( $target_post );
+
+	if ( ! $target_post instanceof WP_Post ) {
+		return true;
+	}
+
+	$post_id = absint( $target_post->ID );
+
+	if ( ! $post_id || is_super_admin() || current_user_can( 'edit_post', $post_id ) ) {
+		return true;
+	}
+
+	if ( urcr_is_page_excluded( $post_id ) ) {
+		return true;
+	}
+
+	$override_global_settings = get_post_meta( $post_id, 'urcr_meta_override_global_settings', true );
+
+	// Per post restriction replaces the global settings entirely.
+	if ( ur_string_to_bool( $override_global_settings ) ) {
+		$allow_to = get_post_meta( $post_id, 'urcr_allow_to', true );
+
+		// A role restriction without any selected role never restricts on the front end.
+		if ( '1' === (string) $allow_to && empty( get_post_meta( $post_id, 'urcr_meta_roles', true ) ) ) {
+			return true;
+		}
+
+		return urcr_is_basic_access_granted(
+			$allow_to,
+			get_post_meta( $post_id, 'urcr_meta_roles', true ),
+			get_post_meta( $post_id, 'urcr_meta_memberships', true )
+		);
+	}
+
+	$resolved_rules = urcr_resolve_access_rules( $target_post );
+
+	// A granting rule always wins over a restricting one.
+	if ( ! $resolved_rules['granted'] && null !== $resolved_rules['rule'] ) {
+		return false;
+	}
+
+	// Whole site members only, applied when no access rule covers the whole site.
+	if ( ! $resolved_rules['granted']
+		&& ! urcr_has_whole_site_access_rule()
+		&& ur_string_to_bool( get_option( 'user_registration_content_restriction_whole_site_access', false ) ) ) {
+
+		$basic_access_granted = urcr_is_basic_access_granted(
+			get_option( 'user_registration_content_restriction_allow_access_to', '0' ),
+			get_option( 'user_registration_content_restriction_allow_to_roles', 'administrator' ),
+			get_option( 'user_registration_content_restriction_allow_to_memberships' )
+		);
+
+		if ( ! $basic_access_granted ) {
+			return false;
+		}
+	}
+
+	// Content drip delays content that no rule has restricted outright.
+	if ( urcr_is_content_drip_pending( $target_post ) ) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * See if the given post is still waiting for its content drip to release.
+ *
+ * @param object $target_post Post to check against.
+ *
+ * @return bool
+ * @since 5.2.8
+ */
+function urcr_is_content_drip_pending( $target_post ) {
+	if ( ! defined( 'UR_PRO_ACTIVE' ) || ! UR_PRO_ACTIVE || ! ur_check_module_activation( 'content-drip' ) ) {
+		return false;
+	}
+
+	if ( ! class_exists( '\WPEverest\URM\ContentDrip\Frontend' ) ) {
+		return false;
+	}
+
+	return \WPEverest\URM\ContentDrip\Frontend::is_drip_pending( $target_post );
+}

--- a/modules/content-restriction/user-registration-content-restriction.php
+++ b/modules/content-restriction/user-registration-content-restriction.php
@@ -66,6 +66,8 @@ class User_Registration_Content_Restriction {
 
 		include_once __DIR__ . '/includes/RestApi/class-urcr-rest-api.php';
 
+		include_once __DIR__ . '/class-urcr-rest-restriction.php';
+
 		if ( $this->is_request( 'admin' ) ) {
 
 			include_once __DIR__ . '/admin/class-urcr-admin-assets.php';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes wpeverest/user-registration-pro#1514 (the issue is filed on the Pro repo; the paired Pro PR carries the `Closes` that will auto-close it). This is the canonical copy — `modules/content-restriction/` and `modules/content-drip/` are byte-identical in both trees and Pro receives them through the `🔄 Synced file(s)` automation.

Membership content restriction was enforced only during normal front-end page rendering, so
WordPress core REST API responses served the full `content.rendered` and `excerpt.rendered` of
restricted published posts and pages to unauthenticated requesters — no account, membership,
payment, cookie or nonce. Collection requests accept `?slug=`, so no ID guessing is needed.

**Root cause.** All enforcement hangs off `template_redirect` / `template_include` in
`modules/content-restriction/class-urcr-frontend.php`, and neither hook runs during a REST
request. The module registered no `rest_prepare_<post_type>`, `rest_pre_dispatch` or
`register_rest_field` at all. `WP_REST_Posts_Controller::prepare_item_for_response()` therefore
built the content itself, untouched.

A useful confirmation that this is precisely a REST gap and not a general one: **RSS feeds were
already correct.** `template_redirect` does fire on `/feed/` requests, so the feed served the
restriction message. Core REST is the one public read path that skips both hooks.

**What this PR adds** (477 insertions, 0 deletions — no existing line is modified):

| File | Change |
|---|---|
| `modules/content-restriction/functions-urcr-core.php` | The shared authorization gate `urcr_is_content_access_granted()`, plus `urcr_get_published_access_rules()`, `urcr_is_access_rule_evaluable()`, `urcr_has_whole_site_access_rule()`, `urcr_resolve_access_rules()`, `urcr_is_basic_access_granted()` and `urcr_is_content_drip_pending()` |
| `modules/content-restriction/class-urcr-rest-restriction.php` | New `URCR_REST_Restriction`; registers `rest_prepare_<post_type>` for every `public` + `show_in_rest` post type |
| `modules/content-drip/includes/Frontend.php` | `is_drip_pending()`, the decision-only counterpart of `apply_content_drip()` |
| `modules/content-restriction/user-registration-content-restriction.php` | Include the new class |

The gate composes the primitives that already exist rather than restating their logic:
`urcr_is_page_excluded()`, `urcr_is_access_rule_enabled()`, `urcr_is_action_specified()`,
`urcr_is_target_post()`, `urcr_is_allow_access()` and `urm_check_user_membership_has_access()`.
It covers all four reported paths — per-post `urcr_meta_override_global_settings` restriction,
per-rule access, whole-site members-only, and content drip.

**Response shape.** A restricted item gets `content` and `excerpt` (plus `description`,
`caption` and `source_url` for attachments) blanked with `protected: true`, matching WP core's
own password-protected convention. Deliberately **not** a 403: a `403` would fail an entire
collection request because one item in it happens to be restricted. Blanking also gives exact
front-end parity — the front end replaces the body but keeps the title visible, and so does this.

Two extension points are provided: `urcr_rest_restricted_post_types` (which post types are
checked) and `urcr_rest_restricted_response_data` (the sanitized payload, for integrators who
want the restriction message returned instead of an empty string).

Access is granted without further checks to `is_super_admin()` and to anyone with `edit_post`
on the item, so the block editor and `context=edit` are unaffected.

### How to test the changes in this Pull Request:

1. On a fresh install with a membership plan, publish a post containing a marker string and
   restrict it — either via **Access Rules** (target the post, condition = that membership) or
   via the per-post **Content Restriction** meta box.
2. Logged out, load the post on the front end. The restriction message shows and the marker is
   absent. (This was already correct before the patch.)
3. Logged out, `GET /wp-json/wp/v2/posts?slug=<slug>&_fields=id,content,excerpt`.
   **Before:** HTTP 200 with the full marker in `content.rendered`.
   **After:** HTTP 200 with `"rendered": "", "protected": true`.
4. Repeat for a page via `/wp-json/wp/v2/pages`, and for a single-item read
   `/wp-json/wp/v2/posts/<id>`.
5. Confirm nothing over-blocks: an unrestricted post still returns full content; a user holding
   the required membership gets the content over REST; an admin gets everything, and
   `?context=edit` still returns `content.raw` so the block editor keeps working.
6. Confirm the collection still lists its other items — only the restricted rows are blanked.

Verified locally against the four fixtures below (REST dispatched in-process per user, and
re-checked over HTTPS with anonymous `curl`):

```
post                                    | anon        | sub, no membership | sub, membership 46 | admin
----------------------------------------------------------------------------------------------------------
post / per-post meta: login required    | BLANK prot. | served             | served             | served
post / access rule: membership 46       | BLANK prot. | BLANK prot.        | served             | served
page / per-post meta: membership 46     | BLANK prot. | BLANK prot.        | served             | served
post / access rule + drip +3650d        | BLANK prot. | BLANK prot.        | BLANK prot.        | served
post / unrestricted                     | served      | served             | served             | served
```

The leak was reproduced on the same fixtures before the patch. Also confirmed: filters register
on all 7 qualifying post types on that install (`post`, `page`, `attachment`, `mto-course`,
`mto-webhook`, `urfd_file`, `product`); whole-site members-only mode gates both REST and the
front end; the front end is unchanged; and `debug.log` gained no new lines across the whole
exercise.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

**Two things a reviewer should weigh in on.**

*The front end is not yet rewired onto the new gate.* The issue asked for one function called by
both the template path and the REST filter; this PR adds that function and wires only REST to it,
leaving the four front-end decision sites untouched. The reason is testability, not laziness:
`basic_restrictions()` remaps the post ID for the WooCommerce shop page (`is_shop()` →
`wc_get_page_id( 'shop' )`), and `restrict_whole_site()` evaluates whole-site rules in a separate
pass ahead of the others — neither could be exercised on the verification install (WooCommerce
inactive), so switching those working paths over risked regressions that could not be proven
either way. Consolidating them is worth a follow-up with WooCommerce installed. Until then the
gate is documented as a decision-only mirror.

Note that `urcr_apply_content_restriction()` (`functions-urcr-core.php:672`), which the issue
nominated as the centralisation point, is not usable as a shared gate: it is an *action*, not a
decision. It mutates `$target_post->post_content` by reference and, for the `redirect` and
`redirect_to_local_page` action types, calls `wp_redirect(); exit` or `wp_die()` — which would
redirect or kill a REST response.

*Content-drip ordering is subtle.* Drip must be evaluated even when an access rule **granted**
access. `advanced_restriction_with_access_rules()` does `continue` on a granting rule and then
calls `apply_content_drip()` after the loop; drip is skipped only when a *restriction* was
applied (`$is_restriction_applied`). Returning early on "granted" silently disables drip, which
would have leaked drip-delayed content to a member whose plan grants access but whose drip has
not released. The gate therefore orders: restricting rule → whole-site basic → drip. The drip
row in the table above covers this.

**PHPCS: 0 violations on the changed lines.** `WPEverest-Core` and `PHPCompatibility` were not
installable on the verification machine, so `phpcs` ran with the `WordPress` standard plus the
exclusions from `phpcs.xml`. Three warnings appeared initially and both causes are annotated
inline: the direct `$wpdb` query (copied from `URCR_Frontend::get_all_access_rules()`, now with a
static per-request cache) and `current_time( 'timestamp' )` (kept byte-identical to
`apply_content_drip()` so both paths release content at the same moment). Please re-run the full
project ruleset in CI.

No changelog or readme edit is included, since this repo updates `readme.txt` / `CHANGELOG.txt`
in the release version-bump commit rather than per fix PR.

### Changelog entry

> Fix - Content restriction bypassed via WordPress core REST API, exposing restricted post and page content to unauthenticated requests.
