### PR TITLE
fix: pr-build-zip uses explicit secrets instead of inherit

### DIFF
--- a/.github/workflows/copilot-review-on-comment.yml
+++ b/.github/workflows/copilot-review-on-comment.yml
@@ -1,6 +1,8 @@
 name: Copilot review on comment
 
 on:
+  pull_request_target:
+    types: [opened]
   issue_comment:
     types: [created]
 

--- a/.github/workflows/copilot-review-on-comment.yml
+++ b/.github/workflows/copilot-review-on-comment.yml
@@ -1,0 +1,12 @@
+# TEMPLATE -- copy into a consuming repo as
+# .github/workflows/copilot-review-on-comment.yml
+name: Copilot review on comment
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  review:
+    uses: wpeverest/.github/.github/workflows/copilot-review-on-comment.yml@master
+    secrets: inherit

--- a/.github/workflows/copilot-review-on-comment.yml
+++ b/.github/workflows/copilot-review-on-comment.yml
@@ -1,5 +1,3 @@
-# TEMPLATE -- copy into a consuming repo as
-# .github/workflows/copilot-review-on-comment.yml
 name: Copilot review on comment
 
 on:
@@ -9,4 +7,5 @@ on:
 jobs:
   review:
     uses: wpeverest/.github/.github/workflows/copilot-review-on-comment.yml@master
-    secrets: inherit
+    secrets:
+      BOT_TOKEN: ${{ secrets.BOT_TOKEN }}

--- a/.github/workflows/pr-build-zip.yml
+++ b/.github/workflows/pr-build-zip.yml
@@ -24,4 +24,14 @@ jobs:
       artifacts-bucket: themegrill-pr-artifacts
       public-base-url: https://themegrill-pr-artifacts.s3.amazonaws.com
       s3-region: us-east-1
-    secrets: inherit
+    # Cross-org call: this repo actually lives in themegrill (transferred
+    # from wpeverest), and the reusable workflow lives in wpeverest/.github --
+    # `secrets: inherit` cannot reach across that boundary reliably (same
+    # issue confirmed on user-registration-pro: worked briefly right after
+    # the transfer, then started failing with "Secret BOT_TOKEN is required,
+    # but not provided" once GitHub's own org-membership check caught up).
+    # Name every secret explicitly instead, same as every other themegrill repo.
+    secrets:
+      BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+      ARTIFACTS_KEY: ${{ secrets.ARTIFACTS_KEY }}
+      ARTIFACTS_SECRET: ${{ secrets.ARTIFACTS_SECRET }}


### PR DESCRIPTION
Same root cause as themegrill/user-registration-pro#1542: this repo actually lives in `themegrill` (transferred from `wpeverest`), but this file still used `secrets: inherit` from before that was discovered.

Confirmed failing for real (3 recent runs, all `Secret BOT_TOKEN is required, but not provided while calling`) -- switches to naming every secret explicitly, same as every other themegrill repo.