### PR TITLE
Fix - Deactivate Licence button did nothing when the pro-activation transient was set

### DIFF
--- a/includes/class-ur-plugin-updater.php
+++ b/includes/class-ur-plugin-updater.php
@@ -447,10 +447,6 @@ class UR_Plugin_Updater extends UR_Plugin_Updates {
 	 * Deactivate a license.
 	 */
 	public function deactivate_license() {
-		if ( get_transient( 'user_registration_pro_activated' ) ) {
-			return;
-		}
-
 		$reset = UR_Updater_Key_API::deactivate(
 			array(
 				'license' => $this->api_key,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Reported symptom (#1530): the License settings page shows a Deactivate License button with blank License Plan / License Expiry fields, and clicking Deactivate sometimes does nothing — leaving the customer stuck, unable to get back to an input field to enter a fresh license key.

The issue's own diagnosis (inconsistent `user-registration_license_key` vs `user_registration_license_key` option naming) does not hold up under inspection: `includes/admin/settings/class-ur-settings-license.php` uses the hyphenated key consistently everywhere it matters. The one underscore-variant reference (`includes/admin/notifications/class-ur-admin-notices.php:496`) is an unrelated survey-notice display condition and does not touch this page.

Root cause, confirmed by reproduction: `UR_Plugin_Updater::deactivate_license()` (`includes/class-ur-plugin-updater.php:449-452`) early-returned whenever the `user_registration_pro_activated` transient was set. That transient is set once when the Pro plugin is activated (`user-registration.php:744`) and is only cleared inside `user_registration_free_deactivate()`, hooked on the same `admin_init` pass at the same default priority as this class's own `admin_init` hook — a hook-ordering race where this guard's read runs before that request's clear. In practice the very first Deactivate click after Pro was ever activated always no-ops, and the stale `_license_key` option is never cleared, which is also why the License Plan/Expiry fields stay blank and the input never comes back.

This is the same underlying mechanism already reported against #1531. Removed the 4-line guard so `deactivate_license()` always runs its normal deactivation flow.

Closes #1530.

### How to test the changes in this Pull Request:

1. On a site with User Registration Pro ever activated (so the `user_registration_pro_activated` transient exists) and a license key option set, go to Settings → License.
2. Click "Deactivate License".
3. Before this fix: the license key option is untouched and the page still shows the Deactivate button / blank plan+expiry. After this fix: the license is actually deactivated and the input field to enter a new key returns.
4. Reproduced directly via WP-CLI (`wp eval`) on a local Pro install: set `user-registration_license_key` + the `user_registration_pro_activated` transient, called `deactivate_license()` — option was unchanged before the fix, cleared after.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

PHPCS: `composer phpcs` on the changed file aborted partway on a pre-existing environment issue (the `WordPress.NamingConventions.PrefixAllGlobals` sniff crashes under the current PHP's `trim()` deprecation, unrelated to this repo). The 2 findings it surfaced before aborting are both pre-existing and outside the touched lines (a repo-wide CRLF line-ending flag, and an indentation flag on an unrelated commented-out line).

### Changelog entry

> Fix - Deactivate License button did nothing when the pro-activation transient was set.
