### PR TITLE
Fix - Stop retrying a Stripe subscription that no longer exists

### DIFF
--- a/modules/membership/includes/Admin/Services/Stripe/StripeService.php
+++ b/modules/membership/includes/Admin/Services/Stripe/StripeService.php
@@ -2908,7 +2908,7 @@ class StripeService {
 			return $response;
 		}
 
-		if ( ! empty( $subscription['member_id'] ) && get_user_meta( $subscription['member_id'], 'urm_retry_unrecoverable_' . $subscription['sub_id'], true ) ) {
+		if ( ! empty( $subscription['member_id'] ) && get_user_meta( absint( $subscription['member_id'] ), 'urm_retry_unrecoverable_' . $subscription['sub_id'], true ) ) {
 			$response['message'] = __( 'Subscription no longer exists at Stripe and will not be retried', 'user-registration' );
 
 			return $response;
@@ -3062,10 +3062,12 @@ class StripeService {
 			// A missing subscription can never come back (deleted, or created under the other API mode),
 			// so stop the daily cron from retrying this row forever.
 			if ( 'resource_missing' === $e->getStripeCode() && ! empty( $subscription['member_id'] ) ) {
+				// The failure detail is already in the log entry above, so store only a timestamp:
+				// it is never empty, and keeps the gateway's message out of user meta.
 				update_user_meta(
-					$subscription['member_id'],
+					absint( $subscription['member_id'] ),
 					'urm_retry_unrecoverable_' . $subscription['sub_id'],
-					$e->getMessage()
+					current_time( 'mysql' )
 				);
 			}
 

--- a/modules/membership/includes/Admin/Services/Stripe/StripeService.php
+++ b/modules/membership/includes/Admin/Services/Stripe/StripeService.php
@@ -2908,6 +2908,12 @@ class StripeService {
 			return $response;
 		}
 
+		if ( ! empty( $subscription['member_id'] ) && get_user_meta( $subscription['member_id'], 'urm_retry_unrecoverable_' . $subscription['sub_id'], true ) ) {
+			$response['message'] = __( 'Subscription no longer exists at Stripe and will not be retried', 'user-registration' );
+
+			return $response;
+		}
+
 		PaymentGatewayLogging::log_general(
 			'stripe',
 			'Retrying Stripe subscription payment' . "\n" . wp_json_encode(
@@ -3047,11 +3053,21 @@ class StripeService {
 						'error_code'      => $e->getStripeCode(),
 						'error_message'   => $e->getMessage(),
 						'subscription_id' => $subscription['subscription_id'],
-						'user_id'         => $subscription['user_id'] ?? 'unknown',
+						'member_id'       => $subscription['member_id'] ?? 'unknown',
 					),
 					JSON_PRETTY_PRINT
 				)
 			);
+
+			// A missing subscription can never come back (deleted, or created under the other API mode),
+			// so stop the daily cron from retrying this row forever.
+			if ( 'resource_missing' === $e->getStripeCode() && ! empty( $subscription['member_id'] ) ) {
+				update_user_meta(
+					$subscription['member_id'],
+					'urm_retry_unrecoverable_' . $subscription['sub_id'],
+					$e->getMessage()
+				);
+			}
 
 			$response['message'] = $e->getMessage();
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes #1420.

`StripeService::retry_subscription()` caught every `ApiErrorException` the same way — log it, return a failure. But `resource_missing` is not a transient error: the gateway subscription is gone for good, either deleted or created under the other API mode. Nothing recorded that, so the daily payment-retry cron asked Stripe for the same impossible object again the next day, and every day after.

Spotted on a live site (Pro 6.2.7, live keys) whose Stripe log holds **1596** identical errors for one row — local subscription #65 stores a test-mode subscription ID, so the lookup can never succeed:

```
No such subscription: 'sub_1TtKb3...'; a similar object exists in test mode,
but a live mode key was used to make this request.
```

First seen 4 July, ~490/day at its peak, still firing 51 days later. The log file is 1.45 MB, mostly this loop.

**The fix.** On `resource_missing`, record a marker and return early on subsequent runs. Two small additions, both in `retry_subscription()` so every retry caller is covered.

The marker is keyed by the **gateway** subscription ID rather than the local row ID, which makes it self-invalidating — if someone corrects the ID on the subscription row, the new ID is not blocked and retries resume. No cleanup code needed.

**Worth noting for sequencing.** #1398 (sync of pro #1396) changes `failed_payment_retry_callback()` to stop discarding the gateway return value: a failed retry now writes an order note and emails the member. Today this loop only touches a log file. Once that lands, a dead subscription ID produces a failed-order row and a customer-facing email *every day* — about 1596 of each on the site above. This guard should land with or before it.

Also corrected in the same log entry: it recorded `'user_id' => $subscription['user_id']`, a key `get_subscriptions_to_retry()` never returns, so all 1596 entries read `"user_id": "unknown"` and could not be traced to a member. It now logs `member_id`.

Two related defects found while investigating are described in #1420 and deliberately left out of this PR: `user_registration_payment_retry_count` is not enforced as an attempt cap (it is only multiplied into a date window), and `NewPaypalService::retry_subscription()` has no equivalent give-up path.

### How to test the changes in this Pull Request:

1. On a site with Stripe in **live** mode and payment retry enabled (`User Registration & Membership > Settings > Payments`), pick a membership subscription row and set its `Subscription / Profile ID` to a **test-mode** ID (`sub_...` created with test keys). A deleted live ID works too.
2. Set the subscription status to `failed` or `expired` so `get_subscriptions_to_retry()` picks it up, and make sure `updated_at` is inside the retry window (`retry count x retry interval` days).
3. Trigger the retry cron (`urm_daily_payment_retry_check`, or run it via WP Crontrol).
4. **Before this change:** `urm-pg-stripe-*.log` gains `ERROR Stripe subscription retry failed` with `error_code: resource_missing`, and it repeats on every subsequent run, forever.
5. **After this change:** the first run still logs the error once, and now stores `urm_retry_unrecoverable_<gateway id>` on the member. Every later run returns early with "Subscription no longer exists at Stripe and will not be retried" and makes no Stripe API call — no new error lines.
6. Confirm the marker self-invalidates: correct the `Subscription / Profile ID` on the row to a valid live ID and trigger the cron again. The retry runs normally, because the marker was keyed to the old ID.
7. Confirm no regression on a healthy subscription: a real live subscription that is genuinely `past_due` still retries and recovers exactly as before.
8. Check the new log entry identifies the member — `"member_id": 76` rather than `"user_id": "unknown"`.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

> Fix - Stop retrying a Stripe membership subscription that no longer exists at Stripe, which filled the payment log with repeating errors.
