### PR TITLE
#1582 Fix - PHP notice and warning when deleting a user not registered through a form

### DIFF
--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -3758,10 +3758,11 @@ if ( ! function_exists( 'ur_delete_user_files_on_user_delete' ) ) {
 		}
 
 		// Delete user uploaded file when user is deleted.
-		if ( class_exists( 'URFU_Uploaded_Data' ) ) {
-			$post = get_post( ur_get_form_id_by_userid( $user_id ) );
+		$form_post = class_exists( 'URFU_Uploaded_Data' ) ? get_post( ur_get_form_id_by_userid( $user_id ) ) : null;
 
-			$form_data_object = json_decode( $post->post_content );
+		// Users not registered through a form have no form post, so no uploaded files to clean up.
+		if ( $form_post instanceof WP_Post ) {
+			$form_data_object = json_decode( $form_post->post_content );
 
 			$file_fields = URFU_Uploaded_Data::get_file_field( $form_data_object );
 


### PR DESCRIPTION
Fixes themegrill/user-registration-pro#1582

## Changes proposed

`ur_delete_user_files_on_user_delete()` is hooked to `delete_user` at priority 10, so it runs for **every** user deletion. It called `get_post( ur_get_form_id_by_userid( $user_id ) )` and dereferenced the result without checking it.

`ur_get_form_id_by_userid()` returns `0` whenever the `ur_form_id` user meta is absent — the normal state for any user not created through a UR form (wp-admin, WP-CLI, import, or another plugin). `get_post( 0 )` returns `null`, so `$post->post_content` emitted a notice and the resulting `null` was passed straight into `URFU_Uploaded_Data::get_file_field()`, which then warned on its `foreach`:

```
PHP Notice:  Trying to get property 'post_content' of non-object in includes/functions-ur-core.php on line 3637
PHP Warning: Invalid argument supplied for foreach() in user-registration-file-upload/includes/class-urfu-uploaded-data.php on line 124
```

Both lines are one cascade from the single unguarded dereference, and they fire on 100% of non-UR user deletions when the File Upload addon is active.

This change folds the `class_exists()` check and the post lookup into one expression and gates the file-cleanup block on `$form_post instanceof WP_Post`:

```php
$form_post = class_exists( 'URFU_Uploaded_Data' ) ? get_post( ur_get_form_id_by_userid( $user_id ) ) : null;

// Users not registered through a form have no form post, so no uploaded files to clean up.
if ( $form_post instanceof WP_Post ) {
```

**Why a guard and not an early `return`.** Returning from inside that block — the obvious one-line fix — also skips the profile-picture cleanup that runs immediately after it. A user with no `ur_form_id` can still have `user_registration_profile_pic_url` set (for example, a wp-admin-created user who uploaded a picture through UR's My Account), so an early return would silently start leaking orphaned profile images on disk on every such deletion. Guarding only the file-fields block keeps that path intact; it is covered by test case C below.

No behaviour change for UR-registered users: they have a real form post, so the block runs exactly as before. There is no data-loss risk in the skipped path either — a user with no form has no UR-uploaded files to clean up, so the function was previously reaching the work only to find nothing to do.

Not a regression. The unguarded `get_post()` dates to `17b733c7` (*UR-217 UR-30 Enhance - Profile Picture and File Upload*, 2022-05-31).

I grepped for other `get_post( ur_get_form_id_by_userid( … ) )` call sites that dereference without a check — this was the only one.

**Companion PR:** themegrill/user-registration-file-upload#60 adds a defensive `is_array()` bail in `URFU_Uploaded_Data::get_file_field()`. That one is not required to clear these log lines (the warning is downstream of the notice this PR fixes), but the method is public and should not warn on an empty argument. The two are independent and can merge in either order.

## How to test

Preconditions: `WP_DEBUG` and `WP_DEBUG_LOG` on, **User Registration File Upload active** (the `class_exists( 'URFU_Uploaded_Data' )` guard means the bug only surfaces when it is), and `wp-content/debug.log` emptied before each case.

**A — regression case: deleting a user with no `ur_form_id`**

1. `wp user create reprouser1 repro1@example.com --role=subscriber --user_pass='X#1234ab'`
2. `wp user delete reprouser1 --yes`
3. `cat wp-content/debug.log` → **expected: empty.** On `develop` this prints the notice and the warning above, every time.
4. Repeat via **Users → All Users → Delete** in wp-admin (choose "Delete all content", i.e. no reassign) — same result. The bug is not WP-CLI specific.

**B — happy path: file cleanup must still work**

1. Create a registration form containing a **File Upload** field, note its form ID and the field's `field_name`.
2. Register a user through that form and upload a file, or set it up directly: `wp user meta update <ID> ur_form_id <form_id>` and `wp user meta update <ID> user_registration_<field_name> <attachment_id>`.
3. Confirm the uploaded file exists under `wp-content/uploads/`.
4. Delete the user, choosing **not** to reassign their content.
5. **Expected:** the uploaded file is gone from disk and `debug.log` is empty.

**C — the edge case an early `return` would have broken**

1. `wp user create reprouser3 repro3@example.com --role=subscriber --user_pass='X#1234ab'` — do **not** set `ur_form_id`.
2. Give it a profile picture: `wp user meta update <ID> user_registration_profile_pic_url <attachment_id>`, and confirm that attachment's file exists on disk.
3. Delete the user without reassigning.
4. **Expected:** the profile picture file is removed from disk and `debug.log` is empty.

**D — reassign path unchanged**

1. Delete any user and choose **"Attribute all content to"** another user.
2. **Expected:** the function returns at its existing `null !== $reassign` guard, no files are touched, `debug.log` empty.

All four were run against `https://urm.me` on WP 7.1 / PHP 8.3 with Pro 6.2.7 and File Upload 1.4.1 active. A, B, C and D pass with this change; A reproduces both log lines without it.

## PHPCS

`composer run-script phpcs -- includes/functions-ur-core.php` — **no violations on the changed lines** (3758-3766). The file carries 90 pre-existing violations elsewhere across its ~12,900 lines; none were introduced by this change and none were touched.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Repository note

`includes/` is listed in `.github/sync-file-list.yml`, so this targets the **free** repo only and reaches `user-registration-pro` through the sync PR. No matching commit should be made in the Pro repo.

## Changelog entry

```
Fix - PHP notice and warning logged when deleting a user not registered through a form.
```
