### PR TITLE
#1401 Fix - Profile picture discarded when saving a profile via ajax

### DIFF
--- a/includes/frontend/class-ur-frontend.php
+++ b/includes/frontend/class-ur-frontend.php
@@ -82,13 +82,11 @@ class UR_Frontend {
 			return $profile;
 		}
 
-		if ( ! ur_option_checked( 'user_registration_ajax_form_submission_on_edit_profile', false ) ) {
-			if ( isset( $_POST['profile_pic_url'] ) || isset( $_POST['profile-pic-url'] ) ) {
-				$value = isset( $_POST['profile_pic_url'] ) ? sanitize_text_field( wp_unslash( $_POST['profile_pic_url'] ) ) : ( isset( $_POST['profile-pic-url'] ) ? sanitize_text_field( wp_unslash( $_POST['profile-pic-url'] ) ) : '' );
-				if ( ! is_array( $value ) && ! ur_is_valid_url( $value ) ) {
-					$valid_form_data['profile_pic_url']        = new stdClass();
-					$valid_form_data['profile_pic_url']->value = $value;
-				}
+		if ( isset( $_POST['profile_pic_url'] ) || isset( $_POST['profile-pic-url'] ) ) {
+			$value = isset( $_POST['profile_pic_url'] ) ? sanitize_text_field( wp_unslash( $_POST['profile_pic_url'] ) ) : ( isset( $_POST['profile-pic-url'] ) ? sanitize_text_field( wp_unslash( $_POST['profile-pic-url'] ) ) : '' );
+			if ( ! is_array( $value ) && ! ur_is_valid_url( $value ) ) {
+				$valid_form_data['profile_pic_url']        = new stdClass();
+				$valid_form_data['profile_pic_url']->value = $value;
 			}
 		} elseif ( isset( $_POST['form_data'] ) ) {
 				$form_data = json_decode( wp_unslash( $_POST['form_data'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized

--- a/includes/functions-ur-core.php
+++ b/includes/functions-ur-core.php
@@ -4415,47 +4415,65 @@ if ( ! function_exists( 'ur_upload_profile_pic' ) ) {
 			}
 		}
 
+		if ( '' === $upload_file ) {
+			update_user_meta( $user_id, 'user_registration_profile_pic_url', '' );
+			return;
+		}
+
 		if ( ! is_numeric( $upload_file ) ) {
 			$upload = ur_maybe_unserialize( crypt_the_string( $upload_file, 'd' ) );
+			$logger = ur_get_logger();
+
+			if ( ! isset( $upload['file_name'], $upload['file_path'], $upload['file_extension'] ) || ! file_exists( $upload['file_path'] ) ) {
+				$logger->warning( sprintf( 'Profile picture not saved for user %d: the uploaded file is no longer available.', $user_id ), array( 'source' => 'user-registration' ) );
+				return;
+			}
+
 			if ( function_exists( 'mime_content_type' ) ) {
-				$upload_file_type = isset( $upload['file_path'] ) ? mime_content_type( $upload['file_path'] ) : '';
+				$upload_file_type = mime_content_type( $upload['file_path'] );
 			} else {
-				$upload_file_info = isset( $upload['file_path'] ) ? wp_check_filetype( $upload['file_path'] ) : '';
+				$upload_file_info = wp_check_filetype( $upload['file_path'] );
 				$upload_file_type = ! empty( $upload_file_info ) ? $upload_file_info['type'] : '';
 			}
 
-			if ( isset( $upload['file_name'] ) && isset( $upload['file_path'] ) && isset( $upload['file_extension'] ) && in_array( $upload_file_type, $valid_extensions ) && in_array( $upload['file_extension'], $valid_ext ) ) {
-				$upload_path = $upload_path . '/';
-				$file_name   = wp_unique_filename( $upload_path, $upload['file_name'] );
-				$file_path   = $upload_path . sanitize_file_name( $file_name );
-				// Check the type of file. We'll use this as the 'post_mime_type'.
-				$filetype = wp_check_filetype( basename( $file_name ), null );
-				$moved    = '';
-
-				if ( basename( $upload['file_path'] ) === $upload['file_name'] ) {
-					$moved = rename( $upload['file_path'], $file_path );
-				}
-
-				if ( $moved ) {
-					$attachment_id = wp_insert_attachment(
-						array(
-							'guid'           => $file_path,
-							'post_mime_type' => $filetype['type'],
-							'post_title'     => preg_replace( '/\.[^.]+$/', '', sanitize_file_name( $file_name ) ),
-							'post_content'   => '',
-							'post_status'    => 'inherit',
-						),
-						$file_path
-					);
-
-					if ( ! is_wp_error( $attachment_id ) ) {
-						include_once ABSPATH . 'wp-admin/includes/image.php';
-
-						// Generate and save the attachment metas into the database.
-						wp_update_attachment_metadata( $attachment_id, wp_generate_attachment_metadata( $attachment_id, $file_path ) );
-					}
-				}
+			if ( ! in_array( $upload_file_type, $valid_extensions, true ) || ! in_array( $upload['file_extension'], $valid_ext, true ) ) {
+				$logger->warning( sprintf( 'Profile picture not saved for user %d: unsupported file type.', $user_id ), array( 'source' => 'user-registration' ) );
+				return;
 			}
+
+			if ( basename( $upload['file_path'] ) !== $upload['file_name'] ) {
+				$logger->warning( sprintf( 'Profile picture not saved for user %d: unexpected upload path.', $user_id ), array( 'source' => 'user-registration' ) );
+				return;
+			}
+
+			$upload_path = $upload_path . '/';
+			$file_name   = wp_unique_filename( $upload_path, $upload['file_name'] );
+			$file_path   = $upload_path . sanitize_file_name( $file_name );
+			$filetype    = wp_check_filetype( basename( $file_name ), null );
+
+			if ( ! rename( $upload['file_path'], $file_path ) ) {
+				$logger->warning( sprintf( 'Profile picture not saved for user %d: could not move the file into %s.', $user_id, $upload_path ), array( 'source' => 'user-registration' ) );
+				return;
+			}
+
+			$attachment_id = wp_insert_attachment(
+				array(
+					'guid'           => $file_path,
+					'post_mime_type' => $filetype['type'],
+					'post_title'     => preg_replace( '/\.[^.]+$/', '', sanitize_file_name( $file_name ) ),
+					'post_content'   => '',
+					'post_status'    => 'inherit',
+				),
+				$file_path
+			);
+
+			if ( is_wp_error( $attachment_id ) || empty( $attachment_id ) ) {
+				$logger->warning( sprintf( 'Profile picture not saved for user %d: the attachment could not be created.', $user_id ), array( 'source' => 'user-registration' ) );
+				return;
+			}
+
+			include_once ABSPATH . 'wp-admin/includes/image.php';
+			wp_update_attachment_metadata( $attachment_id, wp_generate_attachment_metadata( $attachment_id, $file_path ) );
 		} else {
 			// A numeric value is sent when the user keeps their existing profile picture
 			// (the template pre-populates the hidden field with the stored attachment ID).
@@ -4466,7 +4484,7 @@ if ( ! function_exists( 'ur_upload_profile_pic' ) ) {
 			}
 			$attachment_id = $upload_file;
 		}
-		$attachment_id = ! empty( $attachment_id ) ? $attachment_id : '';
+
 		update_user_meta( $user_id, 'user_registration_profile_pic_url', $attachment_id );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/user-registration/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The profile save picked which POST shape to read from the **Ajax Submission on Edit Profile** setting, which is off by default. Admin and membership saves always post `form_data`, so they fell into the wrong branch and never finalised the upload. The file stayed in `temp-uploads/` while the UI reported success. It now branches on the shape actually posted.

`ur_upload_profile_pic()` also wrote user meta unconditionally, so any failure blanked an existing picture. Failures now log and leave the picture alone. Explicit removal still clears it.

Closes themegrill/user-registration-pro#1401.

### How to test the changes in this Pull Request:

Keep **Settings > My Account > Ajax Submission on Edit Profile** off.

1. Edit a user from User Registration > Users, upload a profile picture, save. It persists after a reload and the file is in `uploads/user_registration_uploads/profile-pictures/`.
2. Save again without reloading the page. The picture must still be there.
3. Remove the picture and save. It clears.
4. Repeat on the frontend My Account edit profile page, with the setting off and then on.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [ ] Have you updated the documentation accordingly?

### Changelog entry

Fix - Profile picture discarded when saving a profile via ajax.
