### PR TITLE
UR-4827 Fix - Members charged twice when upgrading to a PayPal subscription plan

### DIFF
--- a/modules/membership/includes/Admin/Services/PaymentGatewaysWebhookActions.php
+++ b/modules/membership/includes/Admin/Services/PaymentGatewaysWebhookActions.php
@@ -2,6 +2,7 @@
 
 namespace WPEverest\URMembership\Admin\Services;
 
+use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WPEverest\URMembership\Admin\Services\Paypal\NewPaypalService;
@@ -22,6 +23,14 @@ class PaymentGatewaysWebhookActions {
 	 * @var PaypalService
 	 */
 	protected $legacy_paypal_service;
+
+	/**
+	 * PayPal's own copy of the event, set when the signature could not be verified but PayPal
+	 * confirmed the event through its API. Processed in place of the posted body.
+	 *
+	 * @var array
+	 */
+	protected $paypal_authoritative_event = array();
 
 	/**
 	 * Constructor.
@@ -327,11 +336,63 @@ class PaymentGatewaysWebhookActions {
 		);
 
 		if ( ! $verified ) {
-			PaymentGatewayLogging::log_error(
+			// UR-4827: PayPal will not verify a signature once the delivery is old, so an event that
+			// fails its first attempt can never pass on retry and the payment behind it is lost while
+			// PayPal retries for days. Ask PayPal for its own copy instead, and process that copy so a
+			// forged body carrying a genuine event ID gains nothing.
+			$event    = json_decode( $request->get_body(), true );
+			$event_id = is_array( $event ) && ! empty( $event['id'] ) ? sanitize_text_field( $event['id'] ) : '';
+
+			$confirmed = $this->paypal_service->fetch_webhook_event( $event_id, $paypal_options );
+
+			if ( is_wp_error( $confirmed ) ) {
+				// Undetermined: could be a network blip or an expired token. Reject so PayPal retries.
+				PaymentGatewayLogging::log_error(
+					'paypal',
+					'PayPal webhook signature verification failed and the event could not be confirmed — request rejected.' . "\n" . wp_json_encode(
+						array(
+							'event_id' => $event_id ?: null,
+							'error'    => $confirmed->get_error_message(),
+						),
+						JSON_PRETTY_PRINT
+					)
+				);
+				return false;
+			}
+
+			if ( empty( $confirmed['id'] ) || ! hash_equals( (string) $event_id, (string) $confirmed['id'] ) ) {
+				// PayPal has no such event. Acknowledge with 200 so it is not retried for days, and do
+				// not process anything.
+				PaymentGatewayLogging::log_error(
+					'paypal',
+					'PayPal webhook rejected: signature invalid and PayPal does not recognise the event.' . "\n" . wp_json_encode(
+						array( 'event_id' => $event_id ?: null ),
+						JSON_PRETTY_PRINT
+					)
+				);
+
+				return new WP_Error(
+					'urm_paypal_webhook_unverified',
+					__( 'PayPal webhook could not be authenticated.', 'user-registration' ),
+					array( 'status' => 200 )
+				);
+			}
+
+			$this->paypal_authoritative_event = $confirmed;
+
+			PaymentGatewayLogging::log_general(
 				'paypal',
-				'PayPal webhook signature verification failed — request rejected.'
+				'PayPal webhook signature failed but PayPal confirmed the event through its API — processing PayPal\'s copy.' . "\n" . wp_json_encode(
+					array(
+						'event_id'   => $event_id,
+						'event_type' => isset( $confirmed['event_type'] ) ? $confirmed['event_type'] : '',
+					),
+					JSON_PRETTY_PRINT
+				),
+				'notice'
 			);
-			return false;
+
+			return true;
 		}
 
 		PaymentGatewayLogging::log_general(
@@ -350,6 +411,19 @@ class PaymentGatewaysWebhookActions {
 	 * @return WP_REST_Response
 	 */
 	public function handle_paypal_webhook( WP_REST_Request $request ) {
+		// Signature failed but PayPal vouched for the event: act on PayPal's copy, never the posted body.
+		if ( ! empty( $this->paypal_authoritative_event ) ) {
+			$event                            = $this->paypal_authoritative_event;
+			$this->paypal_authoritative_event = array();
+
+			$result = $this->paypal_service->handle_webhook_event( $event );
+
+			return new WP_REST_Response(
+				array( 'success' => (bool) $result ),
+				200
+			);
+		}
+
 		$body = $request->get_body();
 
 		if ( empty( $body ) ) {

--- a/modules/membership/includes/Admin/Services/Paypal/NewPaypalService.php
+++ b/modules/membership/includes/Admin/Services/Paypal/NewPaypalService.php
@@ -1272,6 +1272,18 @@ class NewPaypalService {
 		$member_subscription    = $this->members_subscription_repository->get_subscription_data_by_subscription_id( $member_order['subscription_id'] );
 		$is_renewing            = ! empty( $membership_process['renew'] ) && in_array( $member_order['item_id'], $membership_process['renew'], true );
 		$is_upgrading           = ! empty( $membership_process['upgrade'] ) && isset( $membership_process['upgrade'][ $url_params['current_membership_id'] ?? '' ] );
+
+		// UR-4827: that guard is transient user meta. An abandoned or retried attempt can clear it, and
+		// the member then pays and is never moved to the new plan. A pending upgrade payload, or an order
+		// flagged as an upgrade, says so regardless of the guard.
+		if ( ! $is_upgrading ) {
+			$is_upgrading = ! empty( get_user_meta( $member_id, 'urm_next_subscription_data', true ) );
+		}
+
+		if ( ! $is_upgrading && ! empty( $member_order['ID'] ) ) {
+			$upgrade_order_meta = $this->orders_repository->get_order_meta_by_order_id_and_meta_key( $member_order['ID'], 'is_proration_upgrade' );
+			$is_upgrading       = ! empty( $upgrade_order_meta['meta_value'] );
+		}
 		// Also treat as one-time if PayPal returned a token with no subscription_id (proration upgrade).
 		$is_rest_one_time_payment = ( 'paid' === $member_order['order_type'] || 'one-time' === $membership_type )
 			|| ( ! empty( $order_token ) && empty( $paypal_subscription_id ) );
@@ -3582,6 +3594,33 @@ class NewPaypalService {
 		return $this->paypal_rest_request(
 			'GET',
 			'/v2/checkout/orders/' . rawurlencode( $order_id ),
+			null,
+			$paypal_options
+		);
+	}
+
+	/**
+	 * Fetch one webhook event from PayPal by its event ID.
+	 *
+	 * Used when signature verification fails. PayPal refuses to verify a signature once the delivery
+	 * is old, so a retried event can never pass, and every genuine payment behind it is lost. Asking
+	 * PayPal for its own copy of the event settles authenticity just as well.
+	 *
+	 * @param string $event_id       PayPal webhook event ID.
+	 * @param array  $paypal_options Credentials.
+	 * @return array|WP_Error PayPal's copy of the event, or WP_Error when it could not be retrieved.
+	 */
+	public function fetch_webhook_event( $event_id, $paypal_options ) {
+		if ( empty( $event_id ) ) {
+			return new WP_Error(
+				'paypal_missing_event_id',
+				__( 'No PayPal event ID to look up.', 'user-registration' )
+			);
+		}
+
+		return $this->paypal_rest_request(
+			'GET',
+			'/v1/notifications/webhooks-events/' . rawurlencode( $event_id ),
 			null,
 			$paypal_options
 		);

--- a/modules/membership/includes/Admin/Services/Paypal/NewPaypalService.php
+++ b/modules/membership/includes/Admin/Services/Paypal/NewPaypalService.php
@@ -421,6 +421,15 @@ class NewPaypalService {
 			&& ! empty( $coupon_details )
 			&& 0.0 === (float) $final_amount;
 
+		// UR-4600: proration upgrade to a subscription plan. The prorated amount is billed as a
+		// priced first cycle, never as a setup fee — a setup fee stacks on top of the first REGULAR
+		// cycle and charges the member twice at activation.
+		$context['is_proration_upgrade'] = $context['is_subscription']
+			&& $is_upgrading
+			&& ! empty( $response_data['chargeable_amount'] )
+			&& empty( $context['is_full_discount_sub'] )
+			&& ( empty( $data['trial_status'] ) || 'on' !== $data['trial_status'] );
+
 		if (
 			$context['is_subscription'] &&
 			$context['is_upgrading'] &&
@@ -763,19 +772,69 @@ class NewPaypalService {
 			$plan_override = $this->build_subscription_plan_override( $context );
 		}
 
-		// For proration subscription upgrades: charge the prorated amount as a PayPal setup fee.
-		// The plan itself is at the full regular price; the setup fee covers the billing difference.
-		if ( $context['is_upgrading'] && ! empty( $context['response_data']['chargeable_amount'] ) ) {
-			$setup_fee_value = number_format( (float) $context['pre_tax_amount'], 2, '.', '' );
-			if ( ! isset( $plan_override['payment_preferences'] ) ) {
-				$plan_override['payment_preferences'] = array();
-			}
-			$plan_override['payment_preferences']['setup_fee']                = array(
-				'value'         => $setup_fee_value,
-				'currency_code' => $context['currency'],
+		// UR-4600: proration upgrade — bill the prorated amount as the first cycle, then the full
+		// plan price on every cycle after. A setup fee would be charged *in addition to* the first
+		// REGULAR cycle at activation, i.e. the member pays twice on day one.
+		$frequency_spec = $this->build_frequency_spec( $context );
+
+		if ( $context['is_proration_upgrade'] && ! empty( $frequency_spec ) ) {
+			$plan_override['billing_cycles'] = array(
+				array(
+					'frequency'      => $frequency_spec,
+					'tenure_type'    => 'TRIAL',
+					'sequence'       => 1,
+					'total_cycles'   => 1,
+					'pricing_scheme' => array(
+						'fixed_price' => array(
+							'currency_code' => $context['currency'],
+							'value'         => number_format( (float) $context['pre_tax_amount'], 2, '.', '' ),
+						),
+					),
+				),
+				array(
+					'frequency'      => $frequency_spec,
+					'tenure_type'    => 'REGULAR',
+					'sequence'       => 2,
+					'total_cycles'   => 0,
+					'pricing_scheme' => array(
+						'fixed_price' => array(
+							'currency_code' => $context['currency'],
+							'value'         => $context['regular_amount'],
+						),
+					),
+				),
 			);
-			$plan_override['payment_preferences']['setup_fee_failure_action'] = 'CANCEL';
-			$plan_override['payment_preferences']['auto_bill_outstanding']    = true;
+		} elseif ( $has_trial && ! empty( $context['coupon_details'] ) && empty( $context['is_full_discount_sub'] ) && ! empty( $frequency_spec ) ) {
+			// UR-4600: coupon on a plan that has a trial. The free trial (sequence 1) stays free and the
+			// coupon discounts the first *paid* cycle (sequence 2), after which the plan bills at full
+			// price. The whole override used to be skipped on trial plans, so the discount was silently
+			// dropped from every cycle and the member paid full price once the trial ended.
+			$plan_override['billing_cycles'] = array(
+				array(
+					'frequency'      => $frequency_spec,
+					'tenure_type'    => 'TRIAL',
+					'sequence'       => 2,
+					'total_cycles'   => 1,
+					'pricing_scheme' => array(
+						'fixed_price' => array(
+							'currency_code' => $context['currency'],
+							'value'         => ! empty( $context['tax_rate'] ) ? $context['pre_tax_amount'] : $context['final_amount'],
+						),
+					),
+				),
+				array(
+					'frequency'      => $frequency_spec,
+					'tenure_type'    => 'REGULAR',
+					'sequence'       => 3,
+					'total_cycles'   => 0,
+					'pricing_scheme' => array(
+						'fixed_price' => array(
+							'currency_code' => $context['currency'],
+							'value'         => $context['regular_amount'],
+						),
+					),
+				),
+			);
 		}
 
 		if ( ! empty( $plan_override ) ) {
@@ -1009,6 +1068,41 @@ class NewPaypalService {
 		}
 
 		return $override;
+	}
+
+	/**
+	 * Billing frequency of the plan's regular cycle, or empty when the membership has no usable duration.
+	 *
+	 * @param array $context
+	 *
+	 * @return array
+	 */
+	private function build_frequency_spec( $context ) {
+		$subscription_data = ! empty( $context['has_team'] )
+			? array(
+				'duration' => isset( $context['data']['team_data']['team_duration_period'] ) ? $context['data']['team_data']['team_duration_period'] : '',
+				'value'    => isset( $context['data']['team_data']['team_duration_value'] ) ? $context['data']['team_data']['team_duration_value'] : 1,
+			)
+			: ( isset( $context['data']['subscription'] ) ? $context['data']['subscription'] : array() );
+
+		$duration = strtoupper( substr( (string) ( isset( $subscription_data['duration'] ) ? $subscription_data['duration'] : '' ), 0, 1 ) );
+		$value    = max( 1, (int) ( isset( $subscription_data['value'] ) ? $subscription_data['value'] : 1 ) );
+
+		$interval_unit_map = array(
+			'D' => 'DAY',
+			'W' => 'WEEK',
+			'M' => 'MONTH',
+			'Y' => 'YEAR',
+		);
+
+		if ( ! isset( $interval_unit_map[ $duration ] ) ) {
+			return array();
+		}
+
+		return array(
+			'interval_unit'  => $interval_unit_map[ $duration ],
+			'interval_count' => $value,
+		);
 	}
 
 	/**
@@ -1602,6 +1696,42 @@ class NewPaypalService {
 	 *
 	 * @return void
 	 */
+	/**
+	 * Finish an upgrade from the webhook when the member never came back to the site.
+	 *
+	 * Upgrade completion — cancelling the old gateway subscription above all — used to hang off the
+	 * browser redirect handler alone. A member who closed the tab after paying kept the old PayPal
+	 * subscription billing alongside the new one.
+	 *
+	 * @param int $member_id
+	 * @param int $local_sub_id
+	 *
+	 * @return void
+	 */
+	private function maybe_finalize_upgrade_from_webhook( $member_id, $local_sub_id ) {
+		if ( empty( $member_id ) || empty( $local_sub_id ) ) {
+			return;
+		}
+
+		if ( empty( get_user_meta( $member_id, 'urm_next_subscription_data', true ) ) ) {
+			return;
+		}
+
+		PaymentGatewayLogging::log_general(
+			'paypal',
+			'[PAYMENT.SALE.COMPLETED] Finalizing pending upgrade from webhook.' . "\n" . wp_json_encode(
+				array(
+					'member_id'       => $member_id,
+					'subscription_id' => $local_sub_id,
+				),
+				JSON_PRETTY_PRINT
+			),
+			'notice'
+		);
+
+		$this->handle_upgrade_for_paypal( $member_id, $local_sub_id );
+	}
+
 	public function handle_upgrade_for_paypal( $member_id, $subscription_id ) {
 		$get_user_old_subscription = json_decode( get_user_meta( $member_id, 'urm_previous_subscription_data', true ), true );
 		$get_user_old_order        = json_decode( get_user_meta( $member_id, 'urm_previous_order_data', true ), true );
@@ -1656,7 +1786,7 @@ class NewPaypalService {
 		}
 
 		$membership_process = urm_get_membership_process( $member_id );
-		if ( ! empty( $membership_process ) && isset( $membership_process['upgrade'][ $get_user_old_subscription['item_id'] ] ) ) {
+		if ( ! empty( $membership_process ) && ! empty( $get_user_old_subscription['item_id'] ) && isset( $membership_process['upgrade'][ $get_user_old_subscription['item_id'] ] ) ) {
 			unset( $membership_process['upgrade'][ $get_user_old_subscription['item_id'] ] );
 			update_user_meta( $member_id, 'urm_membership_process', $membership_process );
 		}
@@ -2108,6 +2238,11 @@ class NewPaypalService {
 		);
 
 		if ( 'active' === $new_status ) {
+			// Activation is the only signal an upgrade onto a plan with a free trial ever gets — its
+			// first sale is a whole trial period away, and until the old subscription is cancelled the
+			// member pays for both plans.
+			$this->maybe_finalize_upgrade_from_webhook( $member_id, $member_subscription['ID'] );
+
 			$member_order         = $this->members_orders_repository->get_member_orders( $member_id );
 			$current_order_status = isset( $member_order['status'] ) ? $member_order['status'] : '';
 
@@ -2294,6 +2429,7 @@ class NewPaypalService {
 				),
 				'success'
 			);
+			$this->maybe_finalize_upgrade_from_webhook( $user_id, $local_sub_id );
 			return true;
 		}
 
@@ -2324,6 +2460,7 @@ class NewPaypalService {
 				),
 				'success'
 			);
+			$this->maybe_finalize_upgrade_from_webhook( $user_id, $local_sub_id );
 			return true;
 		}
 
@@ -3134,14 +3271,16 @@ class NewPaypalService {
 				),
 			),
 		);
-		// Coupon: plan must define a TRIAL cycle so the subscription override can set a discounted
-		// first-cycle price. Skipped for full-discount subs (UR-4386) — they use a plain REGULAR plan
-		// + future start_time instead.
-		if (
+		// Coupon or proration upgrade: plan must define a TRIAL cycle so the subscription override can
+		// set a discounted/prorated first-cycle price. Skipped for full-discount subs (UR-4386) — they
+		// use a plain REGULAR plan + future start_time instead.
+		$needs_first_cycle_override = ! empty( $context['is_proration_upgrade'] ) || (
 			! empty( $context['coupon_details'] ) &&
 			empty( $context['is_full_discount_sub'] ) &&
 			( empty( $context['data']['trial_status'] ) || 'on' !== $context['data']['trial_status'] )
-		) {
+		);
+
+		if ( $needs_first_cycle_override ) {
 			$billing_cycles = array(
 				array(
 					'frequency'      => array(
@@ -3211,6 +3350,45 @@ class NewPaypalService {
 					),
 				),
 			);
+
+			// UR-4600: with a coupon, the plan needs a second (paid) TRIAL cycle for the subscription
+			// override to discount — PayPal allows at most two trial cycles, so: free trial, discounted
+			// first paid cycle, then REGULAR at full price.
+			if ( ! empty( $context['coupon_details'] ) && empty( $context['is_full_discount_sub'] ) ) {
+				$billing_cycles = array(
+					$billing_cycles[0],
+					array(
+						'frequency'      => array(
+							'interval_unit'  => $interval_unit,
+							'interval_count' => $value,
+						),
+						'tenure_type'    => 'TRIAL',
+						'sequence'       => 2,
+						'total_cycles'   => 1,
+						'pricing_scheme' => array(
+							'fixed_price' => array(
+								'currency_code' => $context['currency'],
+								'value'         => $context['regular_amount'],
+							),
+						),
+					),
+					array(
+						'frequency'      => array(
+							'interval_unit'  => $interval_unit,
+							'interval_count' => $value,
+						),
+						'tenure_type'    => 'REGULAR',
+						'sequence'       => 3,
+						'total_cycles'   => 0,
+						'pricing_scheme' => array(
+							'fixed_price' => array(
+								'currency_code' => $context['currency'],
+								'value'         => $context['regular_amount'],
+							),
+						),
+					),
+				);
+			}
 		}
 
 		$payload = array(
@@ -3265,7 +3443,11 @@ class NewPaypalService {
 				'trial_status'     => isset( $context['data']['trial_status'] ) ? $context['data']['trial_status'] : '',
 				'trial_data'       => isset( $context['data']['trial_data'] ) ? $context['data']['trial_data'] : array(),
 				'tax_rate'         => isset( $context['tax_rate'] ) ? $context['tax_rate'] : 0,
-				'has_coupon_cycle' => ! empty( $context['coupon_details'] ) && empty( $context['is_full_discount_sub'] ) && ( empty( $context['data']['trial_status'] ) || 'on' !== $context['data']['trial_status'] ),
+				// Trial plans now also grow an extra paid TRIAL cycle when a coupon applies, so the key
+				// must separate them from trial plans without one.
+				'has_coupon_cycle' => ! empty( $context['coupon_details'] ) && empty( $context['is_full_discount_sub'] ),
+				// Upgrade plans carry an extra TRIAL cycle — must not reuse the plain plan's cached id.
+				'has_upgrade_cycle' => ! empty( $context['is_proration_upgrade'] ),
 			)
 		);
 	}
@@ -3808,6 +3990,14 @@ class NewPaypalService {
 		$count_errors  = 0;
 
 		foreach ( $events as $event ) {
+			// PayPal drops the event_type filter on paginated pages, so events of other types come
+			// back too. A SALE.DENIED/REFUNDED resource carries the same fields as a completed sale
+			// and would otherwise be written as a completed order.
+			if ( 'PAYMENT.SALE.COMPLETED' !== ( $event['event_type'] ?? '' ) ) {
+				++$count_skipped;
+				continue;
+			}
+
 			$resource               = isset( $event['resource'] ) ? $event['resource'] : array();
 			$transaction_id         = isset( $resource['id'] ) ? $resource['id'] : '';
 			$paypal_subscription_id = isset( $resource['billing_agreement_id'] ) ? $resource['billing_agreement_id'] : '';
@@ -3887,22 +4077,33 @@ class NewPaypalService {
 			$local_sub_id = $membership_subscription['ID'];
 			$user_id      = $membership_subscription['user_id'];
 
-			// Replace placeholder order (transaction_id = PayPal subscription ID) if one exists.
+			// Placeholder order (transaction_id = PayPal subscription ID): stamp the real sale ID on it,
+			// same as the webhook path. Deleting and recreating it loses the order's meta (tax, coupon,
+			// local currency, proration flag), its note and its creator.
 			$placeholder = $this->orders_repository->get_order_by_transaction_id( $paypal_subscription_id );
 			if ( ! empty( $placeholder ) && ! empty( $placeholder['ID'] ) ) {
+				$this->orders_repository->update(
+					$placeholder['ID'],
+					array(
+						'status'         => 'completed',
+						'transaction_id' => $transaction_id,
+					)
+				);
 				$logger->info(
-					'[Backfill][PayPal][Subscription][Payments] Deleting placeholder order.' . "\n" . wp_json_encode(
+					'[Backfill][PayPal][Subscription][Payments] Placeholder order updated with real transaction ID.' . "\n" . wp_json_encode(
 						array(
-							'event_type'             => 'placeholder_deleted',
+							'event_type'             => 'placeholder_updated',
 							'local_sub_id'           => $local_sub_id,
-							'placeholder_order_id'   => $placeholder['ID'],
+							'order_id'               => $placeholder['ID'],
 							'paypal_subscription_id' => $paypal_subscription_id,
+							'transaction_id'         => $transaction_id,
 						),
 						JSON_PRETTY_PRINT
 					),
 					array( 'source' => 'urm-missed-payment-backfill' )
 				);
-				$this->orders_repository->delete( $placeholder['ID'] );
+				++$count_updated;
+				continue;
 			}
 
 			// Update a pending order in place rather than creating a duplicate.
@@ -3938,6 +4139,39 @@ class NewPaypalService {
 					'success'
 				);
 				++$count_updated;
+				continue;
+			}
+
+			// A second sale landing on a subscription within the hour is not a renewal — it means the
+			// member was charged twice. Record the order (the money did move) but make it loud.
+			if (
+				! empty( $existing_pending['ID'] ) &&
+				'completed' === ( $existing_pending['status'] ?? '' ) &&
+				$transaction_id !== ( $existing_pending['transaction_id'] ?? '' ) &&
+				! empty( $existing_pending['created_at'] ) &&
+				abs( strtotime( $created_at ) - strtotime( $existing_pending['created_at'] ) ) < HOUR_IN_SECONDS
+			) {
+				PaymentGatewayLogging::log_error(
+					'paypal',
+					'[Backfill][PayPal][Subscription][Payments] Possible duplicate charge — second sale on this subscription within the hour.' . "\n" . wp_json_encode(
+						array(
+							'event_type'              => 'possible_duplicate_charge',
+							'member_id'               => $user_id,
+							'subscription_id'         => $local_sub_id,
+							'existing_order_id'       => $existing_pending['ID'],
+							'existing_transaction_id' => $existing_pending['transaction_id'] ?? '',
+							'new_transaction_id'      => $transaction_id,
+							'amount'                  => $gross_amount,
+						),
+						JSON_PRETTY_PRINT
+					)
+				);
+			}
+
+			// Re-check immediately before insert: the webhook handler may have recorded this same sale
+			// while the loop was making API calls, and transaction_id has no unique index.
+			if ( ! empty( $this->orders_repository->get_order_by_transaction_id( $transaction_id ) ) ) {
+				++$count_skipped;
 				continue;
 			}
 
@@ -4070,6 +4304,12 @@ class NewPaypalService {
 		}
 
 		foreach ( $events as $event ) {
+			// Paginated pages come back unfiltered — a DENIED capture must not complete an order.
+			if ( 'PAYMENT.CAPTURE.COMPLETED' !== ( $event['event_type'] ?? '' ) ) {
+				++$count_skipped;
+				continue;
+			}
+
 			$resource   = isset( $event['resource'] ) ? $event['resource'] : array();
 			$capture_id = isset( $resource['id'] ) ? $resource['id'] : '';
 			$custom_id  = isset( $resource['custom_id'] ) ? $resource['custom_id'] : '';
@@ -4335,8 +4575,12 @@ class NewPaypalService {
 						break;
 					}
 				}
-			} else {
+			} elseif ( 'PAYMENT.SALE.REFUNDED' === $event_type ) {
 				$transaction_id = isset( $resource['sale_id'] ) ? $resource['sale_id'] : null;
+			} else {
+				// Paginated pages come back unfiltered — never treat a foreign event as a refund.
+				++$total_skipped;
+				continue;
 			}
 
 			if ( empty( $transaction_id ) ) {

--- a/modules/membership/includes/Admin/Services/SubscriptionService.php
+++ b/modules/membership/includes/Admin/Services/SubscriptionService.php
@@ -637,7 +637,9 @@ class SubscriptionService {
 		$member_service = new MembersService();
 		$member_service->update_user_meta( $members_data, $user->ID );
 
-		if ( isset( $data['upgrade'] ) && $data['upgrade'] && 'subscription' === $current_membership_details['type'] && 'bank' !== $payment_method && 'off' === $selected_membership_details['trial_status'] && ! isset( $upgrade_details['delayed_until'] ) ) {
+		// calculate_membership_upgrade_cost() always returns a delayed_until key, so isset() here was
+		// always true and this whole branch never ran — the old gateway subscription kept billing.
+		if ( isset( $data['upgrade'] ) && $data['upgrade'] && 'subscription' === $current_membership_details['type'] && 'bank' !== $payment_method && 'off' === $selected_membership_details['trial_status'] && empty( $upgrade_details['delayed_until'] ) ) {
 
 			$cancel_subscription = $this->subscription_repository->cancel_subscription_by_id( $current_subscription_id, false );
 
@@ -775,6 +777,13 @@ class SubscriptionService {
 
 		if ( ! $result['status'] ) {
 			return $result;
+		}
+
+		// UR-4600: when the destination plan carries its own trial, nothing is due today — the first
+		// charge lands when the trial ends. Without this the member pays the proration (the full plan
+		// price on a free->subscription upgrade) up front and still gets a "free" trial afterwards.
+		if ( $new_plan_has_trial ) {
+			$result['chargeable_amount'] = 0;
 		}
 
 		return array(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1447. Root cause and full write-up: https://themegrill.atlassian.net/browse/UR-4827

Proration upgrades onto a PayPal subscription plan were billed as a setup fee stacked on a full-price first cycle — two full charges on day one instead of one. `create_paypal_subscription_order()` now bills the prorated amount as the plan's first billing cycle (TRIAL tenure, priced), then the regular price on every cycle after, the same pattern already used for coupon pricing.

Also fixed while in this code path:
- Upgrades onto a plan with its own free trial charged the full proration up front and still granted the trial (`SubscriptionService::calculate_membership_upgrade_cost()` now zeroes `chargeable_amount` when the destination plan has a trial).
- The old gateway subscription cancel-on-upgrade guard checked `isset( $upgrade_details['delayed_until'] )`, but that key is always set, so the branch never ran and old subscriptions kept billing alongside the new one.
- Upgrade finalization (cancelling the old subscription) depended on the member's browser returning to the site; it's now also triggered from the PayPal webhook so a closed tab doesn't leave two subscriptions billing.
- PayPal webhook signature verification failures are now confirmed against PayPal's own event API instead of being dropped outright.

### How to test the changes in this Pull Request:

1. PayPal sandbox REST credentials, mode Test.
2. Free plan + $10/mo Subscription plan, same membership group, upgrade path enabled.
3. Register on Free, log in, upgrade to the subscription plan via PayPal.
4. Before approving, PayPal's "due today" summary should show $10, not $20.
5. Approve; PayPal activity shows one transaction, not two.

### Types of changes:

* [x] Bug fix (non-breaking change which fixes an issue)

### Changelog entry

> Fix - Members charged twice when upgrading to a PayPal subscription plan.
